### PR TITLE
▣ Partial inclusion of $compute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,7 @@ dependencies = [
  "chrono",
  "dotenv",
  "lazy_static",
+ "regex",
  "serde",
  "serde_json",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 lazy_static = "1.4"
+regex = "1"
 

--- a/src/database/sqlite/common/context/contextualizer.rs
+++ b/src/database/sqlite/common/context/contextualizer.rs
@@ -10,10 +10,10 @@ pub struct ContextualizerMetadata {
 impl ContextualizerMetadata {
     pub fn new(metadata: EntityDescription) -> Self {
         let columns = metadata.columns.into_iter().map(|(k, v)| {
-            (k, ContextualizerColumnMetadata {
-                column_name: v.column_name,
-                column_type: v.column_type,
-            })
+            (k, ContextualizerColumnMetadata::new( 
+                v.column_name,
+                v.column_type,
+            ))
         }).collect::<HashMap<_, _>>();
 
         let relationships = metadata.relationships.into_iter().map(|(k, v)| {
@@ -40,10 +40,10 @@ impl ContextualizerMetadata {
 
 fn convert_to_contextualizer_entity(entity: &EntityDescription) -> ContextualizerEntityDescription {
     let columns = entity.columns.iter().map(|(k, v)| {
-        (k.clone(), ContextualizerColumnMetadata {
-            column_name: v.column_name.clone(),
-            column_type: v.column_type,
-        })
+        (k.clone(), ContextualizerColumnMetadata::new(
+            v.column_name.to_string(), 
+            v.column_type
+        ))
     }).collect::<HashMap<_, _>>();
 
     let relationships = entity.relationships.iter().map(|(k, v)| {
@@ -77,19 +77,113 @@ fn convert_to_contextualizer_relationship_type(relationship_type: &RelationshipT
 }
 
 #[derive(Debug, Clone)]
-pub struct ContextualizerColumnMetadata {
+pub enum ContextualizerColumnMetadata {
+    Original {
+        column_name: String,
+        column_type: TypeId,
+    },
+    Dynamic {
+        column_name: String,
+        column_type: TypeId,
+        specification: ComputeSpecificationMetadata
+    },
+}
+
+// [Compute Specification] //
+
+#[derive(Debug, Clone)]
+pub struct ComputeSpecificationMetadata {
+    pub operation_type: ComputeOperation
+}
+
+#[derive(Debug, Clone)]
+pub enum ComputeOperation {
+    Arithmetic {
+        operation: ComputeArithmeticOperation
+    },
+    Alias {
+        operation: ComputeAliasOperation
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ComputeOperand {
+    pub table_name: String,
     pub column_name: String,
-    pub column_type: TypeId,
+}
+
+#[derive(Debug, Clone)]
+pub enum ComputeArithmeticOperation {
+    Addition {
+        left_operand: ComputeOperand,
+        right_operand: ComputeOperand
+    },
+    Subtration {
+        left_operand: ComputeOperand,
+        right_operand: ComputeOperand
+    },
+    Multiplication {
+        left_operand: ComputeOperand,
+        right_operand: ComputeOperand
+    },
+    Division {
+        left_operand: ComputeOperand,
+        right_operand: ComputeOperand
+    },
+    Module {
+        left_operand: ComputeOperand,
+        right_operand: ComputeOperand
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ComputeAliasOperation {
+    pub table_name: String,
+    pub column_name: String
+}
+
+// [Compute Specification] //
+
+impl ContextualizerColumnMetadata {
+    pub fn new(column_name: String, column_type: TypeId) -> Self {
+        ContextualizerColumnMetadata::Original {
+            column_name,
+            column_type,
+        }
+    }
+
+    pub fn new_dynamically(column_name: String, column_type: TypeId, specification: ComputeSpecificationMetadata) -> Self {
+        ContextualizerColumnMetadata::Dynamic {
+            column_name,
+            column_type,
+            specification
+        }
+    }
+
+    pub fn column_name(&self) -> &String {
+        match self {
+            ContextualizerColumnMetadata::Original { column_name, .. } => column_name,
+            ContextualizerColumnMetadata::Dynamic { column_name, .. } => column_name,
+        }
+    }
+
+    pub fn column_type(&self) -> TypeId {
+        match self {
+            ContextualizerColumnMetadata::Original { column_type, .. } => *column_type,
+            ContextualizerColumnMetadata::Dynamic { column_type, .. } => *column_type,
+        }
+    }
 }
 
 impl Default for ContextualizerColumnMetadata {
     fn default() -> Self {
-        ContextualizerColumnMetadata {
+        ContextualizerColumnMetadata::Original {
             column_name: "".to_string(),
             column_type: TypeId::of::<String>(),
         }
     }
-}
+}   
+
 
 #[derive(Debug, Clone)]
 pub enum ContextualizerRelationshipType {

--- a/src/database/sqlite/database.rs
+++ b/src/database/sqlite/database.rs
@@ -163,11 +163,11 @@ impl Database {
                     // [Parsed Metadata | The name of metadata will not the same for database]
                     let parsed_metadata = ColumnMetadata {
                         column_name: key.to_string(),
-                        column_type: metadata.column_type
+                        column_type: metadata.column_type()
                     };
 
                     if let Some(value) = Self::fetch_column_value(row, &parsed_metadata) {
-                        json_row.insert(metadata.column_name.to_string(), value);
+                        json_row.insert(metadata.column_name().to_string(), value);
                     }
                 }
                 PropertyType::RelationalProperty { properties, .. } => { 
@@ -202,11 +202,11 @@ impl Database {
                     // [Parsed Metadata | The name of metadata will not the same for database]
                     let parsed_metadata = ColumnMetadata {
                         column_name: key.to_string(),
-                        column_type: metadata.column_type
+                        column_type: metadata.column_type()
                     };
 
                     if let Some(value) = Self::fetch_column_value(row, &parsed_metadata) {
-                        json_row.insert(metadata.column_name.to_string(), value);
+                        json_row.insert(metadata.column_name().to_string(), value);
                     }
                 }
                 PropertyType::RelationalProperty { properties, .. } => {

--- a/src/dto/query_params.rs
+++ b/src/dto/query_params.rs
@@ -13,6 +13,8 @@ pub struct QueryParams {
     #[serde(rename = "$skip")]
     pub skip: Option<i32>,
     #[serde(rename = "$expand")]
-    pub expand: Option<String>
+    pub expand: Option<String>,
+    #[serde(rename = "$compute")]
+    pub compute: Option<String>,
 }
 

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -22,6 +22,9 @@ pub mod query {
                     pub mod orderby {
                         pub mod token;
                     }
+                    pub mod compute {
+                        pub mod token;
+                    }
                 }
             }
 
@@ -38,8 +41,24 @@ pub mod query {
                     }
                 }
 
+                pub mod compute {
+                    pub mod compute;
+
+                    pub mod token {
+                        pub mod tokenization;
+                    }
+                    pub mod context {
+                        pub mod context;
+                    }
+                }
+
                 pub mod select {
                     pub mod select;
+
+                    // [Specific module the handle $compute operations]
+                    pub mod compute {
+                        pub mod compute;
+                    }
 
                     pub mod token {
                         pub mod tokenization;
@@ -48,6 +67,11 @@ pub mod query {
     
                 pub mod filter {
                     pub mod filter;
+
+                    // [Specific module the handle $compute operations]
+                    pub mod compute {
+                        pub mod compute;
+                    }
     
                     pub mod token {
                         pub mod tokenization;
@@ -56,6 +80,11 @@ pub mod query {
    
                 pub mod orderby {
                     pub mod orderby;
+
+                    // [Specific module the handle $compute operations]
+                    pub mod compute {
+                        pub mod compute;
+                    }
 
                     pub mod token {
                         pub mod tokenization;

--- a/src/services/query/database/sqlite/common/tokens/compute/token.rs
+++ b/src/services/query/database/sqlite/common/tokens/compute/token.rs
@@ -1,0 +1,77 @@
+use std::any::TypeId;
+
+use crate::database::sqlite::common::context::contextualizer::{ContextualizerColumnMetadata, ContextualizerEntityDescription};
+
+#[derive(Debug, Clone)]
+pub enum Token {
+    Operation {
+        operation_type: Operation
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Operation {
+    Arithmetic {
+        operation: ArithmeticOperation
+    },
+    Alias {
+        operation: AliasOperation
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Operand {
+    pub metadata: ContextualizerEntityDescription,
+    pub column_metadata: ContextualizerColumnMetadata,
+}
+
+#[derive(Debug, Clone)]
+pub enum ArithmeticOperation {
+    Addition {
+        left_operand: Operand,
+        right_operand: Operand,
+        alias_name: String,
+        alias_type: TypeId
+    },
+    Subtration {
+        left_operand: Operand,
+        right_operand: Operand,
+        alias_name: String,
+        alias_type: TypeId
+    },
+    Multiplication {
+        left_operand: Operand,
+        right_operand: Operand,
+        alias_name: String,
+        alias_type: TypeId
+    },
+    Division {
+        left_operand: Operand,
+        right_operand: Operand,
+        alias_name: String,
+        alias_type: TypeId
+    },
+    Module {
+        left_operand: Operand,
+        right_operand: Operand,
+        alias_name: String,
+        alias_type: TypeId
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AliasOperation {
+    pub metadata: ContextualizerEntityDescription,
+    pub column_metadata: ContextualizerColumnMetadata,
+    pub alias_name: String,
+    pub alias_type: TypeId
+}
+
+
+impl Token {
+    pub fn new_operation(operation_type: Operation) -> Self {
+        Token::Operation {
+            operation_type
+        }
+    }
+}

--- a/src/services/query/database/sqlite/operations/compute/compute.rs
+++ b/src/services/query/database/sqlite/operations/compute/compute.rs
@@ -1,0 +1,34 @@
+use crate::database::sqlite::common::context::contextualizer::ContextualizerMetadata;
+use crate::services::query::database::sqlite::common::tokens::compute::token::Token;
+
+use super::{token::tokenization::Tokenization, context::context::Context};
+
+pub struct Compute;
+
+impl Compute {
+    pub fn process(
+        text: Option<&str>,
+        contextualizer: &mut ContextualizerMetadata,
+    ) -> Result<(), String> {
+
+        let error = |message: String| -> String {
+            format!("Invalid $compute: {}", message)
+        };
+
+        let mut tokens: Vec<Token> = Vec::new();
+
+        if let Some(text) = text {
+            tokens = match Tokenization::tokenize(text, contextualizer) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
+        }
+
+        match Context::resolve_context(&tokens, contextualizer){
+            Err(err) => return Err(error(err)),
+            Ok(value) => value
+        };
+
+        Ok(())
+    }   
+}

--- a/src/services/query/database/sqlite/operations/compute/context/context.rs
+++ b/src/services/query/database/sqlite/operations/compute/context/context.rs
@@ -1,0 +1,168 @@
+use crate::database::sqlite::common::context::contextualizer::{ComputeAliasOperation, ComputeArithmeticOperation, ComputeOperand, ComputeOperation, ComputeSpecificationMetadata, ContextualizerColumnMetadata, ContextualizerMetadata};
+use crate::services::query::database::sqlite::common::tokens::compute::token::{ArithmeticOperation, Operation, Token};
+
+pub struct Context;
+
+impl Context {
+    pub fn resolve_context(
+        tokens: &[Token],
+        contextualizer: &mut ContextualizerMetadata,
+    ) -> Result<(), String> {  
+
+        let mut metadata = contextualizer.get_context();
+
+        for token in tokens {
+            match token {
+                Token::Operation { operation_type: operation} => {
+                    match operation {
+                        Operation::Alias { operation} => {
+
+                            metadata.columns.insert(operation.alias_name.to_string(), 
+                                ContextualizerColumnMetadata::Dynamic {
+
+                                    column_name: operation.alias_name.to_string(),
+                                    column_type: operation.alias_type,
+
+                                    specification: ComputeSpecificationMetadata {
+                                        operation_type: ComputeOperation::Alias {
+                                            operation: ComputeAliasOperation {
+                                                table_name: operation.metadata.table_name.clone(),
+                                                column_name: operation.column_metadata.column_name().clone()
+                                            }
+                                        }
+                                    }
+                                });
+
+                        },
+                        Operation::Arithmetic { operation } => {
+
+                            match operation {
+                                ArithmeticOperation::Addition { left_operand, right_operand, alias_name, alias_type } => {
+                                    metadata.columns.insert(alias_name.to_string(), 
+                                        ContextualizerColumnMetadata::Dynamic {
+                                        
+                                            column_name: alias_name.to_string(),
+                                            column_type: *alias_type,
+                                        
+                                            specification: ComputeSpecificationMetadata {
+                                                operation_type: ComputeOperation::Arithmetic {
+                                                    operation: ComputeArithmeticOperation::Addition {
+                                                        left_operand: ComputeOperand {
+                                                            table_name: left_operand.metadata.table_name.clone(),
+                                                            column_name: left_operand.column_metadata.column_name().clone()
+                                                        },
+                                                        right_operand: ComputeOperand {
+                                                            table_name: right_operand.metadata.table_name.clone(),
+                                                            column_name: right_operand.column_metadata.column_name().clone()
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        });
+                                },
+                                ArithmeticOperation::Subtration { left_operand, right_operand, alias_name, alias_type } => {
+                                    metadata.columns.insert(alias_name.to_string(), 
+                                        ContextualizerColumnMetadata::Dynamic {
+                                        
+                                            column_name: alias_name.to_string(),
+                                            column_type: *alias_type,
+                                        
+                                            specification: ComputeSpecificationMetadata {
+                                                operation_type: ComputeOperation::Arithmetic {
+                                                    operation: ComputeArithmeticOperation::Subtration {
+                                                        left_operand: ComputeOperand {
+                                                            table_name: left_operand.metadata.table_name.clone(),
+                                                            column_name: left_operand.column_metadata.column_name().clone()
+                                                        },
+                                                        right_operand: ComputeOperand {
+                                                            table_name: right_operand.metadata.table_name.clone(),
+                                                            column_name: right_operand.column_metadata.column_name().clone()
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        });
+                                },
+                                ArithmeticOperation::Multiplication { left_operand, right_operand, alias_name, alias_type } => {
+                                    metadata.columns.insert(alias_name.to_string(), 
+                                        ContextualizerColumnMetadata::Dynamic {
+                                        
+                                            column_name: alias_name.to_string(),
+                                            column_type: *alias_type,
+                                        
+                                            specification: ComputeSpecificationMetadata {
+                                                operation_type: ComputeOperation::Arithmetic {
+                                                    operation: ComputeArithmeticOperation::Multiplication {
+                                                        left_operand: ComputeOperand {
+                                                            table_name: left_operand.metadata.table_name.clone(),
+                                                            column_name: left_operand.column_metadata.column_name().clone()
+                                                        },
+                                                        right_operand: ComputeOperand {
+                                                            table_name: right_operand.metadata.table_name.clone(),
+                                                            column_name: right_operand.column_metadata.column_name().clone()
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        });
+                                },
+                                ArithmeticOperation::Division { left_operand, right_operand, alias_name, alias_type } => {
+                                    metadata.columns.insert(alias_name.to_string(), 
+                                        ContextualizerColumnMetadata::Dynamic {
+                                        
+                                            column_name: alias_name.to_string(),
+                                            column_type: *alias_type,
+                                        
+                                            specification: ComputeSpecificationMetadata {
+                                                operation_type: ComputeOperation::Arithmetic {
+                                                    operation: ComputeArithmeticOperation::Division {
+                                                        left_operand: ComputeOperand {
+                                                            table_name: left_operand.metadata.table_name.clone(),
+                                                            column_name: left_operand.column_metadata.column_name().clone()
+                                                        },
+                                                        right_operand: ComputeOperand {
+                                                            table_name: right_operand.metadata.table_name.clone(),
+                                                            column_name: right_operand.column_metadata.column_name().clone()
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        });
+                                },
+                                ArithmeticOperation::Module { left_operand, right_operand, alias_name, alias_type } => {
+                                    metadata.columns.insert(alias_name.to_string(), 
+                                        ContextualizerColumnMetadata::Dynamic {
+                                        
+                                            column_name: alias_name.to_string(),
+                                            column_type: *alias_type,
+                                        
+                                            specification: ComputeSpecificationMetadata {
+                                                operation_type: ComputeOperation::Arithmetic {
+                                                    operation: ComputeArithmeticOperation::Module {
+                                                        left_operand: ComputeOperand {
+                                                            table_name: left_operand.metadata.table_name.clone(),
+                                                            column_name: left_operand.column_metadata.column_name().clone()
+                                                        },
+                                                        right_operand: ComputeOperand {
+                                                            table_name: right_operand.metadata.table_name.clone(),
+                                                            column_name: right_operand.column_metadata.column_name().clone()
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        });
+                                }
+                            }
+
+                        }
+                    }
+
+                }
+            }
+        }
+
+        contextualizer.update_context(metadata.clone());
+
+        Ok(())
+    }
+}

--- a/src/services/query/database/sqlite/operations/compute/token/tokenization.rs
+++ b/src/services/query/database/sqlite/operations/compute/token/tokenization.rs
@@ -1,0 +1,414 @@
+use regex::Regex;
+use std::{any::TypeId, cell::RefCell, collections::{HashMap, HashSet}, rc::Rc};
+use chrono::{NaiveDate, NaiveDateTime};
+use lazy_static::lazy_static;
+use dynamic_queries_api::EventfulPeekable;
+
+use crate::{database::sqlite::common::context::contextualizer::{ContextualizerColumnMetadata, ContextualizerEntityDescription, ContextualizerMetadata}, services::query::database::sqlite::common::tokens::compute::token::{AliasOperation, ArithmeticOperation, Operand}};
+use crate::services::query::database::sqlite::common::tokens::compute::token::{Token, Operation};
+
+lazy_static! {
+    static ref OPERATORS: HashSet<&'static str> = {
+        let mut set = HashSet::new();
+        set.insert("as");
+        set
+    }; 
+
+    static ref ARITHMETIC_OPERATORS: HashSet<&'static str> = {
+        let mut set = HashSet::new();
+        set.insert("add");
+        set.insert("sub");
+        set.insert("mul");
+        set.insert("div");
+        set.insert("mod");
+        set
+    }; 
+
+    static ref VALID_ARITHMETIC_OPERATORS: HashMap<TypeId, Vec<&'static str>> = {
+        let mut map = HashMap::new();
+
+        map.insert(TypeId::of::<String>(), vec![]);
+        map.insert(TypeId::of::<Option<String>>(), vec![]);
+        
+        map.insert(TypeId::of::<bool>(), vec![]);
+        map.insert(TypeId::of::<Option<bool>>(), vec![]);
+
+        map.insert(TypeId::of::<i16>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<i32>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<i64>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<i128>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<Option<i16>>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<Option<i32>>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<Option<i64>>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<Option<i128>>(), vec!["add", "sub", "mul", "div", "mod"]);
+
+        map.insert(TypeId::of::<f32>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<f64>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<Option<f32>>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<Option<f64>>(), vec!["add", "sub", "mul", "div", "mod"]);
+
+        map.insert(TypeId::of::<NaiveDate>(), vec![]);
+        map.insert(TypeId::of::<NaiveDateTime>(), vec![]);
+        map.insert(TypeId::of::<Option<NaiveDate>>(), vec![]);
+        map.insert(TypeId::of::<Option<NaiveDateTime>>(), vec![]);
+        
+        map
+    };
+}
+
+pub struct Tokenization;
+
+impl Tokenization {
+    fn split(text: &str) -> Result<Vec<String>, String> {
+        let mut tokens = Vec::new();
+        let mut current_token = String::new();
+        
+        for char in text.chars() {
+            match char {
+                ',' => {
+                    if !current_token.trim().is_empty() {
+                        tokens.push(current_token.trim().to_string());
+                        current_token.clear();
+                    }
+                    tokens.push(char.to_string());
+                },
+                ' ' => {
+                    if !current_token.trim().is_empty() {
+                        tokens.push(current_token.trim().to_string());
+                        current_token.clear();
+                    }
+                },
+                _ => {
+                    current_token.push(char);
+                }
+            }
+        }
+    
+        // [Add the last token if necessary]
+        if !current_token.trim().is_empty() {
+            tokens.push(current_token.trim().to_string());
+        }
+    
+        Ok(tokens)
+    }
+
+    fn resolve_nested_metadata(metadata: &ContextualizerEntityDescription, token: &str) -> Result<(ContextualizerEntityDescription, ContextualizerColumnMetadata), String> {
+        let parts: Vec<&str> = token.split('/').collect();
+
+        if parts.len() < 2 {
+            return Err(format!("Invalid nested token format: {}", token));
+        }
+
+        let mut current_metadata = metadata.clone();
+
+        for (i, part) in parts.iter().enumerate() {
+            if i == parts.len() - 1 {
+                
+                // [Last part should be a field in the related entity]
+                let metadata = current_metadata.clone();
+
+                let column_metadata = metadata
+                    .columns
+                    .get(*part)
+                    .cloned()
+                    .ok_or_else(|| format!("Invalid token in related entity: {}", part))?;
+
+                return Ok((metadata, column_metadata));
+
+            } else {
+                // [Intermediate parts should be relationships]
+                let relationship = current_metadata
+                    .relationships
+                    .get(*part)
+                    .ok_or_else(|| format!("Invalid related entity: {}", part))?;
+
+                // [Expanded]
+                if !relationship.expanded {
+                    return Err(format!("Non expanded relation: {}", part));
+                }
+
+                current_metadata = relationship.related_entity_metadata.clone();
+            }
+        }
+
+        Err(format!("Unexpected error resolving metadata for token: {}", token))
+    }
+
+    fn resolve_non_nested_metadata(metadata: &ContextualizerEntityDescription, token: &str) -> Result<(ContextualizerEntityDescription, ContextualizerColumnMetadata), String> {
+        
+        let metadata = metadata.clone();
+
+        let column_metadata = metadata
+            .columns
+            .get(token)
+            .cloned()
+            .ok_or_else(|| format!("Invalid token: {}", token))?;
+
+            return Ok((metadata, column_metadata));
+    }
+
+    fn get_metadata(metadata: &ContextualizerEntityDescription, token: &str) -> Result<(ContextualizerEntityDescription, ContextualizerColumnMetadata), String> {
+        if token.contains('/') {
+            Self::resolve_nested_metadata(metadata, token)
+        } else {
+            Self::resolve_non_nested_metadata(metadata, token)
+        }
+    }
+    
+    fn get_operation(metadata: &ContextualizerEntityDescription, tokens_iter: &mut EventfulPeekable<std::slice::Iter<'_, String>>, token: &str) -> Result<Operation, String> {
+        
+        // [ArithmeticOperation]
+        // [column_name + arithmetic_operator + column_name + alias + alias_name]
+
+        // [AliasOperation]
+        // [column_name + alias + alias_name]
+
+        // [left-side metadata]
+        let left_operand: &str = token; 
+
+        let (left_operand_metadata, left_operand_column_metadata ) = Self::get_metadata(&metadata, left_operand)?;
+
+        // [first-operator]
+        let first_operator: &str = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {}", token))?; 
+
+        Self::validate_operator(first_operator)?;
+
+        // [AliasOperation]
+        if first_operator == "as" {
+            
+            // [alias]
+            let alias_name: &str = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {}", first_operator))?; 
+
+            Self::validate_alias_name(alias_name)?;
+
+            let alias_operation = 
+                AliasOperation {
+                    metadata: left_operand_metadata.clone(),
+                    column_metadata: left_operand_column_metadata.clone(),
+                    alias_name: alias_name.to_string(),
+                    alias_type: left_operand_column_metadata.column_type(),
+            };
+
+            return Ok(Operation::Alias { operation: alias_operation });
+        }
+
+        // [ArithmeticOperation]
+
+        // [right-side metadata]
+        let right_operand: &str = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {}", first_operator))?; 
+
+        let (right_operand_metadata, right_operand_column_metadata ) = Self::get_metadata(&metadata, right_operand)?;
+
+        Self::validate_arithmetic_operator(first_operator, &left_operand_column_metadata, &right_operand_column_metadata)?;
+
+        // [second-operator]
+        let second_operator: &str = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {}", token))?; 
+
+        if second_operator != "as" {
+            return Err(format!("Operator '{}' is not a valid operator", second_operator));
+        }
+
+        let common_type = left_operand_column_metadata.column_type();
+
+        // [alias]
+        let alias_name: &str = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {}", second_operator))?; 
+
+        Self::validate_alias_name(alias_name)?;
+
+        let arithmetic_operation = match first_operator {
+            "add" => ArithmeticOperation::Addition {
+                left_operand: Operand {
+                    metadata: left_operand_metadata,
+                    column_metadata: left_operand_column_metadata
+                },
+                right_operand: Operand {
+                    metadata: right_operand_metadata,
+                    column_metadata: right_operand_column_metadata
+                },
+                alias_name: alias_name.to_string(),
+                alias_type: common_type
+            },
+            "sub" => ArithmeticOperation::Subtration {
+                left_operand: Operand {
+                    metadata: left_operand_metadata,
+                    column_metadata: left_operand_column_metadata
+                },
+                right_operand: Operand {
+                    metadata: right_operand_metadata,
+                    column_metadata: right_operand_column_metadata
+                },
+                alias_name: alias_name.to_string(),
+                alias_type: common_type
+            },
+            "mul" => ArithmeticOperation::Multiplication {
+                left_operand: Operand {
+                    metadata: left_operand_metadata,
+                    column_metadata: left_operand_column_metadata
+                },
+                right_operand: Operand {
+                    metadata: right_operand_metadata,
+                    column_metadata: right_operand_column_metadata
+                },
+                alias_name: alias_name.to_string(),
+                alias_type: common_type
+            },
+            "div" => ArithmeticOperation::Division {
+                left_operand: Operand {
+                    metadata: left_operand_metadata,
+                    column_metadata: left_operand_column_metadata
+                },
+                right_operand: Operand {
+                    metadata: right_operand_metadata,
+                    column_metadata: right_operand_column_metadata
+                },
+                alias_name: alias_name.to_string(),
+                alias_type: common_type
+            },
+            "mod" => ArithmeticOperation::Module {
+                left_operand: Operand {
+                    metadata: left_operand_metadata,
+                    column_metadata: left_operand_column_metadata
+                },
+                right_operand: Operand {
+                    metadata: right_operand_metadata,
+                    column_metadata: right_operand_column_metadata
+                },
+                alias_name: alias_name.to_string(),
+                alias_type: common_type
+            },
+            _ => return Err(format!("Unsupported arithmetic operator '{}' between  left-operand '{}' and right-operand '{}'", left_operand_column_metadata.column_name(), right_operand_column_metadata.column_name(), first_operator)),
+        };
+
+        return Ok(Operation::Arithmetic { operation:  arithmetic_operation });
+    }
+
+    fn validate_alias_name(alias_name: &str) -> Result<(), String> {
+        
+        let alias_name_regex = Regex::new(r"^[A-Za-z0-9-_]+$").unwrap();
+        
+        if !alias_name_regex.is_match(alias_name) {
+            return Err(format!("Invalid alias name '{}'. [A-Za-z0-9-_]", alias_name));
+        }
+
+        Ok(())
+    }
+
+    fn validate_operator(operator: &str) -> Result<(), String> {
+        if !OPERATORS.contains(operator) && !ARITHMETIC_OPERATORS.contains(operator) {
+            return Err(format!("Operator '{}' is not a valid operator", operator));
+        }
+        Ok(())
+    }
+
+    fn validate_arithmetic_operator(operator: &str, left_operand_column_metadata: &ContextualizerColumnMetadata, right_operand_column_metadata: &ContextualizerColumnMetadata) -> Result<(), String> {
+        
+        if left_operand_column_metadata.column_type() != right_operand_column_metadata.column_type() {
+            return Err(format!("The left-operand '{}' and right-operand '{}' must be same types to realizer the operation '{}'.", left_operand_column_metadata.column_name(), right_operand_column_metadata.column_name(), operator));
+        }
+
+        let common_type = left_operand_column_metadata.column_type();
+
+        if let Some(valid_operators) = VALID_ARITHMETIC_OPERATORS.get(&common_type) {
+            if !valid_operators.contains(&operator) {
+                return Err(format!("The left-operand '{}' and right-operand '{}' cannot be apply to the operation '{}'", left_operand_column_metadata.column_name(), right_operand_column_metadata.column_name(), operator));
+            } 
+        }
+
+        Ok(())
+    }
+
+    pub fn tokenize(text: &str, contextualizer: &ContextualizerMetadata) -> Result<Vec<Token>, String> {
+    
+        let mut tokens: Vec<Token> = Vec::new();
+
+        let mut previous_alias: HashSet<String> = HashSet::new();
+    
+        let splited: &[String] = &Self::split(text)?;
+
+        let metadata = contextualizer.get_context();
+
+        // [Context]
+        let context: Rc<RefCell<String>> = Rc::new(RefCell::new(String::new()));
+            
+        let mut tokens_iter = EventfulPeekable::new(
+            splited.iter(),
+            {
+                let context = Rc::clone(&context);
+                move |item| {
+                    context.borrow_mut().push_str(&format!(" {} ", item));
+                }
+            },
+        );
+
+        // [Parser state]: Tracks the last token type
+        enum LastToken {
+            None,
+            Comma,
+            Clause
+        }
+    
+        let mut last_token = LastToken::None;
+
+        let error_with_context = |message: String| -> String {
+            format!("{} [Context: {}]", message, context.borrow())
+        };
+    
+        while let Some(token) = tokens_iter.next() {
+            match token.as_str() {
+                "," => {
+                    match last_token {
+                        LastToken::Clause => {
+                            last_token = LastToken::Comma;
+                        },
+                        _ => {
+                            return Err(error_with_context(String::from("Comma must follow a property")));
+                        }
+                    }
+                },
+                _ => {
+                    match last_token {
+                        LastToken::None | LastToken::Comma => {
+
+                            // [Operation]
+                            let operation: Operation = match Self::get_operation(&metadata, &mut tokens_iter, &token) {
+                                Err(err) => return Err(error_with_context(err)),
+                                Ok(value) => value
+                            };
+                
+                            // [Alias]
+                            let alias_name = match &operation {
+                                Operation::Alias { operation } => &operation.alias_name,
+
+                                Operation::Arithmetic { operation } => match operation {
+                                    ArithmeticOperation::Addition { alias_name, .. } => alias_name,
+                                    ArithmeticOperation::Subtration { alias_name, .. } => alias_name,
+                                    ArithmeticOperation::Multiplication { alias_name, .. } => alias_name,
+                                    ArithmeticOperation::Division { alias_name, .. } => alias_name,
+                                    ArithmeticOperation::Module { alias_name, .. } => alias_name,
+                                }
+                            };
+
+                            if metadata.columns.contains_key(alias_name) {
+                                return Err(error_with_context(format!("The alias '{}' is reserved for an original table field with the same name.", alias_name)));
+                            }
+                        
+                            if previous_alias.contains(alias_name) {
+                                return Err(error_with_context(format!("The alias '{}' is already mapped.", alias_name)));
+                            }
+                            previous_alias.insert(alias_name.clone());
+
+                            // [Token]
+                            tokens.push(Token::new_operation(operation));
+
+                            last_token = LastToken::Clause;
+                        }
+                        _ => {
+                            return Err(error_with_context( String::from("Clause must follow a comma or be setted in begin")));
+                        }
+                    }
+                }
+            }
+        }
+        Ok(tokens)
+    }
+}

--- a/src/services/query/database/sqlite/operations/expand/expand.rs
+++ b/src/services/query/database/sqlite/operations/expand/expand.rs
@@ -16,16 +16,30 @@ impl Expand {
         contextualizer: &mut ContextualizerMetadata,
     ) -> Result<String, String> {
 
+        let error = |message: String| -> String {
+            format!("Invalid $expand: {}", message)
+        };
+
         let mut sql: String = String::from("");
         let mut tokens: Vec<Token> = Vec::new();
 
         if let Some(text) = text {
-            tokens = Tokenization::tokenize(text, contextualizer)?;
 
-            sql = Self::process_with_tokens(&tokens, alias_manager)?;
+            tokens = match Tokenization::tokenize(text, contextualizer) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
+
+            sql = match Self::process_with_tokens(&tokens, alias_manager) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
         }
 
-        Context::resolve_context(&tokens, contextualizer)?;
+        match Context::resolve_context(&tokens, contextualizer) {
+            Err(err) => return Err(error(err)),
+            Ok(value) => value
+        };
 
         Ok(sql)
     }

--- a/src/services/query/database/sqlite/operations/expand/token/tokenization.rs
+++ b/src/services/query/database/sqlite/operations/expand/token/tokenization.rs
@@ -117,7 +117,7 @@ impl Tokenization {
         let mut last_token = LastToken::None;
 
         let error_with_context = |message: String| -> String {
-            format!("Invalid $expand: {} [Context: {}]", message, context.borrow())
+            format!("{} [Context: {}]", message, context.borrow())
         };
     
         while let Some(token) = tokens_iter.next() {

--- a/src/services/query/database/sqlite/operations/filter/compute/compute.rs
+++ b/src/services/query/database/sqlite/operations/filter/compute/compute.rs
@@ -1,0 +1,600 @@
+use std::collections::HashMap;
+use lazy_static::lazy_static;
+
+use crate::database::mssql::common::context::contextualizer::ContextualizerEntityDescription;
+use crate::services::query::common::alias_manager::QueryAliasManager;
+use crate::database::sqlite::common::context::contextualizer::{ContextualizerColumnMetadata, ComputeArithmeticOperation, ComputeOperation, ComputeSpecificationMetadata};
+use crate::services::query::database::sqlite::common::tokens::filter::token::Operation;
+
+#[derive(Hash, Eq, PartialEq, Debug)]
+enum OperationFilterType {
+    Equal,
+    NotEqual,
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual,
+    Like,
+    InValues,
+}
+
+lazy_static! {
+    static ref OPERATORS: HashMap<OperationFilterType, &'static str> = {
+        let mut map = HashMap::new();
+        map.insert(OperationFilterType::Equal, "=");
+        map.insert(OperationFilterType::NotEqual, "<>");
+        map.insert(OperationFilterType::GreaterThan, ">");
+        map.insert(OperationFilterType::GreaterThanOrEqual, ">=");
+        map.insert(OperationFilterType::LessThan, "<");
+        map.insert(OperationFilterType::LessThanOrEqual, "<=");
+        map.insert(OperationFilterType::Like, "LIKE");
+        map.insert(OperationFilterType::InValues, "IN");
+        map
+    };
+}
+
+#[derive(Hash, Eq, PartialEq, Debug)]
+enum ArithmeticOperationType {
+    Addition,
+    Subtration,
+    Multiplication,
+    Division,
+    Module
+}
+
+lazy_static! {
+    static ref ARITHMETIC_OPERATORS: HashMap<ArithmeticOperationType, &'static str> = {
+        let mut map = HashMap::new();
+        map.insert(ArithmeticOperationType::Addition, "+");
+        map.insert(ArithmeticOperationType::Subtration, "-");
+        map.insert(ArithmeticOperationType::Multiplication, "*");
+        map.insert(ArithmeticOperationType::Division, "/");
+        map.insert(ArithmeticOperationType::Module, "%");
+        map
+    };
+}
+
+pub struct Compute;
+
+impl Compute {
+    pub fn process_computed_column(
+        column_metadata: &ContextualizerColumnMetadata,
+        filter_operation: &Operation,
+        sql: &mut String,
+        alias_manager: &mut QueryAliasManager,
+    ) -> Result<(), String> {
+
+        let get_operator = |operator_type: &OperationFilterType| -> &'static str {
+            OPERATORS
+                .get(operator_type)
+                .ok_or_else(|| format!("Operator not found for {:?}", operator_type))
+                .unwrap()
+        };
+
+        match column_metadata {
+            ContextualizerColumnMetadata::Dynamic { specification, .. } => {
+                match &specification.operation_type {
+                    ComputeOperation::Alias { operation } => {
+
+                        let original_table = alias_manager.get_or_create_table_alias(&operation.table_name);
+                        let original_column_name = &operation.column_name;
+
+                        match &filter_operation {
+                            Operation::Equal { value } => {
+
+                                let operator = get_operator(&OperationFilterType::Equal);
+
+                                sql.push_str(&format!(
+                                    "([{}].[{}]) {} {}",
+                                    original_table, original_column_name, operator, value
+                                ));
+                            },
+                            Operation::NotEqual { value } => {
+
+                                let operator = get_operator(&OperationFilterType::NotEqual);
+
+                                sql.push_str(&format!(
+                                    "([{}].[{}]) {} {}",
+                                    original_table, original_column_name, operator, value
+                                ));
+                            },
+                            Operation::GreaterThan { value } => {
+
+                                let operator = get_operator(&OperationFilterType::GreaterThan);
+
+                                sql.push_str(&format!(
+                                    "([{}].[{}]) {} {}",
+                                    original_table, original_column_name, operator, value
+                                ));
+                            },
+                            Operation::GreaterThanOrEqual { value } => {
+
+                                let operator = get_operator(&OperationFilterType::GreaterThanOrEqual);
+
+                                sql.push_str(&format!(
+                                    "([{}].[{}]) {} {}",
+                                    original_table, original_column_name, operator, value
+                                ));
+                            },
+                            Operation::LessThan { value } => {
+
+                                let operator = get_operator(&OperationFilterType::LessThan);
+
+                                sql.push_str(&format!(
+                                    "([{}].[{}]) {} {}",
+                                    original_table, original_column_name, operator, value
+                                ));
+                            },
+                            Operation::LessThanOrEqual { value } => {
+
+                                let operator = get_operator(&OperationFilterType::LessThanOrEqual);
+
+                                sql.push_str(&format!(
+                                    "([{}].[{}]) {} {}",
+                                    original_table, original_column_name, operator, value
+                                ));
+                            },
+                            Operation::Like { value } => {
+
+                                let operator = get_operator(&OperationFilterType::Like);
+
+                                sql.push_str(&format!(
+                                    "([{}].[{}]) {} {}",
+                                    original_table, original_column_name, operator, value
+                                ));
+                            },
+                            Operation::InValues { value } => {
+
+                                let operator = get_operator(&OperationFilterType::InValues);
+
+                                sql.push_str(&format!(
+                                    "([{}].[{}]) {} {}",
+                                    original_table, original_column_name, operator, value.join(",")
+                                ));
+                            },
+                        }
+        
+                    },
+                    ComputeOperation::Arithmetic { operation } => {
+                        let get_arithmetic_operator = |arithmetic_operator_type: &ArithmeticOperationType| -> &'static str {
+                            ARITHMETIC_OPERATORS
+                                .get(arithmetic_operator_type)
+                                .ok_or_else(|| format!("Invalid $compute: Arithmetic operator not found for {:?}", arithmetic_operator_type))
+                                .unwrap()
+                        };
+        
+                        match operation {
+                            ComputeArithmeticOperation::Addition { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Addition);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+              
+                                match &filter_operation {
+                                    Operation::Equal { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Equal);
+          
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::NotEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::NotEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::Like { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Like);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::InValues { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::InValues);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} ({})",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value.join(",")
+                                        ));
+                                    },
+                                }
+                            },
+                            ComputeArithmeticOperation::Subtration { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Subtration);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+              
+                                match &filter_operation {
+                                    Operation::Equal { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Equal);
+          
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::NotEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::NotEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::Like { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Like);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::InValues { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::InValues);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} ({})",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value.join(",")
+                                        ));
+                                    },
+                                }
+                            },
+                            ComputeArithmeticOperation::Multiplication { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Multiplication);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+              
+                                match &filter_operation {
+                                    Operation::Equal { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Equal);
+          
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::NotEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::NotEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::Like { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Like);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::InValues { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::InValues);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} ({})",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value.join(",")
+                                        ));
+                                    },
+                                }
+                            },
+                            ComputeArithmeticOperation::Division { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Division);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+              
+                                match &filter_operation {
+                                    Operation::Equal { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Equal);
+          
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::NotEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::NotEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::Like { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Like);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::InValues { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::InValues);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} ({})",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value.join(",")
+                                        ));
+                                    },
+                                }
+                            }
+                            ComputeArithmeticOperation::Module { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Module);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+              
+                                match &filter_operation {
+                                    Operation::Equal { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Equal);
+          
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::NotEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::NotEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::Like { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Like);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::InValues { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::InValues);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} ({})",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value.join(",")
+                                        ));
+                                    },
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            _ => return Err(String::from("Provide only computed columns to 'process_computed_column'"))
+        }
+        Ok(())
+    }
+}

--- a/src/services/query/database/sqlite/operations/filter/filter.rs
+++ b/src/services/query/database/sqlite/operations/filter/filter.rs
@@ -2,9 +2,10 @@ use std::collections::HashMap;
 use lazy_static::lazy_static;
 
 use crate::services::query::common::alias_manager::QueryAliasManager;
-use crate::database::sqlite::common::context::contextualizer::ContextualizerMetadata;
+use crate::database::sqlite::common::context::contextualizer::{ContextualizerMetadata, ContextualizerColumnMetadata};
 use crate::services::query::database::sqlite::common::tokens::filter::token::{Increment, Operation, Parentheses, Token};
 
+use super::compute::compute::Compute;
 use super::token::tokenization::Tokenization;
 
 #[derive(Hash, Eq, PartialEq, Debug)]
@@ -43,13 +44,23 @@ impl Filter {
         contextualizer: &ContextualizerMetadata,
     ) -> Result<String, String> {
 
+        let error = |message: String| -> String {
+            format!("Invalid $filter: {}", message)
+        };
+
         let mut sql: String = String::from("");
         let mut tokens: Vec<Token> = Vec::new();
 
         if let Some(text) = text {
-            tokens = Tokenization::tokenize(text, contextualizer)?;
+            tokens = match Tokenization::tokenize(text, contextualizer) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
 
-            sql = Self::process_with_tokens(&tokens, alias_manager)?;
+            sql = match Self::process_with_tokens(&tokens, alias_manager){
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
         }
 
         // [There no changes in context for while...]
@@ -69,7 +80,7 @@ impl Filter {
         let get_operator = |operator_type: &OperationFilterType| -> &'static str {
             OPERATORS
                 .get(operator_type)
-                .ok_or_else(|| format!("Invalid $filter: Operator not found for {:?}", operator_type))
+                .ok_or_else(|| format!("Operator not found for {:?}", operator_type))
                 .unwrap()
         };
 
@@ -96,82 +107,91 @@ impl Filter {
                     }
                 },
                 Token::Property { metadata, column_metadata, operation } => {
-                    let alias = alias_manager.get_or_create_table_alias(&metadata.table_name);
+                    
+                    match column_metadata {
+                        ContextualizerColumnMetadata::Original { column_name, .. } => {
 
-                    match &operation {
-                        Operation::Equal { value } => {
+                            let alias = alias_manager.get_or_create_table_alias(&metadata.table_name);
 
-                            let operator = get_operator(&OperationFilterType::Equal);
+                                match &operation {
+                                    Operation::Equal { value } => {
 
-                            sql.push_str(&format!(
-                                "[{}].[{}] {} {}",
-                                alias, column_metadata.column_name, operator, value
-                            ));
+                                        let operator = get_operator(&OperationFilterType::Equal);
+
+                                        sql.push_str(&format!(
+                                            "[{}].[{}] {} {}",
+                                            alias, column_metadata.column_name(), operator, value
+                                        ));
+                                    },
+                                    Operation::NotEqual { value } => {
+
+                                        let operator = get_operator(&OperationFilterType::NotEqual);
+
+                                        sql.push_str(&format!(
+                                            "[{}].[{}] {} {}",
+                                            alias, column_metadata.column_name(), operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThan { value } => {
+
+                                        let operator = get_operator(&OperationFilterType::GreaterThan);
+
+                                        sql.push_str(&format!(
+                                            "[{}].[{}] {} {}",
+                                            alias, column_metadata.column_name(), operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThanOrEqual { value } => {
+
+                                        let operator = get_operator(&OperationFilterType::GreaterThanOrEqual);
+
+                                        sql.push_str(&format!(
+                                            "[{}].[{}] {} {}",
+                                            alias, column_metadata.column_name(), operator, value
+                                        ));
+                                    },
+                                    Operation::LessThan { value } => {
+
+                                        let operator = get_operator(&OperationFilterType::LessThan);
+
+                                        sql.push_str(&format!(
+                                            "[{}].[{}] {} {}",
+                                            alias, column_metadata.column_name(), operator, value
+                                        ));
+                                    },
+                                    Operation::LessThanOrEqual { value } => {
+                                        
+                                        let operator = get_operator(&OperationFilterType::LessThanOrEqual);
+
+                                        sql.push_str(&format!(
+                                            "[{}].[{}] {} {}",
+                                            alias, column_metadata.column_name(), operator, value
+                                        ));
+                                    },
+                                    Operation::Like { value } => {
+                                        
+                                        let operator = get_operator(&OperationFilterType::Like);
+
+                                        sql.push_str(&format!(
+                                            "[{}].[{}] {} {}",
+                                            alias, column_metadata.column_name(), operator, value
+                                        ));
+                                    },
+                                    Operation::InValues { value } => {
+
+                                        let operator = get_operator(&OperationFilterType::InValues);
+
+                                        sql.push_str(&format!(
+                                            "[{}].[{}] {} ({})",
+                                            alias, column_metadata.column_name(), operator, value.join(",")
+                                        ));
+                                    },
+                                }
                         },
-                        Operation::NotEqual { value } => {
-
-                            let operator = get_operator(&OperationFilterType::NotEqual);
-
-                            sql.push_str(&format!(
-                                "[{}].[{}] {} {}",
-                                alias, column_metadata.column_name, operator, value
-                            ));
-                        },
-                        Operation::GreaterThan { value } => {
-
-                            let operator = get_operator(&OperationFilterType::GreaterThan);
-
-                            sql.push_str(&format!(
-                                "[{}].[{}] {} {}",
-                                alias, column_metadata.column_name, operator, value
-                            ));
-                        },
-                        Operation::GreaterThanOrEqual { value } => {
-
-                            let operator = get_operator(&OperationFilterType::GreaterThanOrEqual);
-
-                            sql.push_str(&format!(
-                                "[{}].[{}] {} {}",
-                                alias, column_metadata.column_name, operator, value
-                            ));
-                        },
-                        Operation::LessThan { value } => {
-
-                            let operator = get_operator(&OperationFilterType::LessThan);
-
-                            sql.push_str(&format!(
-                                "[{}].[{}] {} {}",
-                                alias, column_metadata.column_name, operator, value
-                            ));
-                        },
-                        Operation::LessThanOrEqual { value } => {
-                            
-                            let operator = get_operator(&OperationFilterType::LessThanOrEqual);
-
-                            sql.push_str(&format!(
-                                "[{}].[{}] {} {}",
-                                alias, column_metadata.column_name, operator, value
-                            ));
-                        },
-                        Operation::Like { value } => {
-                            
-                            let operator = get_operator(&OperationFilterType::Like);
-
-                            sql.push_str(&format!(
-                                "[{}].[{}] {} {}",
-                                alias, column_metadata.column_name, operator, value
-                            ));
-                        },
-                        Operation::InValues { value } => {
-
-                            let operator = get_operator(&OperationFilterType::InValues);
-
-                            sql.push_str(&format!(
-                                "[{}].[{}] {} ({})",
-                                alias, column_metadata.column_name, operator, value.join(",")
-                            ));
-                        },
-                    }
+                        ContextualizerColumnMetadata::Dynamic { .. } => { 
+                            Compute::process_computed_column(column_metadata, operation, &mut sql, alias_manager)?
+                        } 
+                    }  
                 },
             }
         }

--- a/src/services/query/database/sqlite/operations/filter/token/tokenization.rs
+++ b/src/services/query/database/sqlite/operations/filter/token/tokenization.rs
@@ -56,34 +56,34 @@ pub struct Tokenization;
 
 impl Tokenization {
     fn format_value(value: &str, column_metadata: &ContextualizerColumnMetadata) -> Result<String, String> {
-        let is_nullable = column_metadata.column_type == TypeId::of::<Option<i32>>()
-            || column_metadata.column_type == TypeId::of::<Option<i64>>()
-            || column_metadata.column_type == TypeId::of::<Option<f32>>()
-            || column_metadata.column_type == TypeId::of::<Option<f64>>()
-            || column_metadata.column_type == TypeId::of::<Option<bool>>()
-            || column_metadata.column_type == TypeId::of::<Option<String>>()
-            || column_metadata.column_type == TypeId::of::<Option<NaiveDate>>()
-            || column_metadata.column_type == TypeId::of::<Option<NaiveDateTime>>();
+        let is_nullable = column_metadata.column_type() == TypeId::of::<Option<i32>>()
+            || column_metadata.column_type() == TypeId::of::<Option<i64>>()
+            || column_metadata.column_type() == TypeId::of::<Option<f32>>()
+            || column_metadata.column_type() == TypeId::of::<Option<f64>>()
+            || column_metadata.column_type() == TypeId::of::<Option<bool>>()
+            || column_metadata.column_type() == TypeId::of::<Option<String>>()
+            || column_metadata.column_type() == TypeId::of::<Option<NaiveDate>>()
+            || column_metadata.column_type() == TypeId::of::<Option<NaiveDateTime>>();
     
         match value {
             "None" if is_nullable => Ok(String::from("NULL")),
             "None" => Err(format!(
                 "None value not allowed for non-nullable column: {}",
-                column_metadata.column_name
+                column_metadata.column_name()
             )),
-            _ => match column_metadata.column_type {
+            _ => match column_metadata.column_type() {
 
-                _ if column_metadata.column_type == TypeId::of::<Option<i32>>() ||
-                     column_metadata.column_type == TypeId::of::<Option<i64>>() ||
-                     column_metadata.column_type == TypeId::of::<Option<f32>>() ||
-                     column_metadata.column_type == TypeId::of::<Option<f64>>() => {
+                _ if column_metadata.column_type() == TypeId::of::<Option<i32>>() ||
+                     column_metadata.column_type() == TypeId::of::<Option<i64>>() ||
+                     column_metadata.column_type() == TypeId::of::<Option<f32>>() ||
+                     column_metadata.column_type() == TypeId::of::<Option<f64>>() => {
                         value.parse::<f64>().map_or_else(
                         |_| Err(format!("Invalid numeric value: {}", value)),
                         |_| Ok(value.to_string())
                     )
                 }
     
-                _ if column_metadata.column_type == TypeId::of::<Option<bool>>() => {
+                _ if column_metadata.column_type() == TypeId::of::<Option<bool>>() => {
                     match value.to_lowercase().as_str() {
                         "true" => Ok(String::from("TRUE")),
                         "false" => Ok(String::from("FALSE")),
@@ -91,9 +91,9 @@ impl Tokenization {
                     }
                 }
     
-                _ if column_metadata.column_type == TypeId::of::<Option<String>>() ||
-                     column_metadata.column_type == TypeId::of::<Option<NaiveDate>>() ||
-                     column_metadata.column_type == TypeId::of::<Option<NaiveDateTime>>() => {
+                _ if column_metadata.column_type() == TypeId::of::<Option<String>>() ||
+                     column_metadata.column_type() == TypeId::of::<Option<NaiveDate>>() ||
+                     column_metadata.column_type() == TypeId::of::<Option<NaiveDateTime>>() => {
                     if value.starts_with("'") && value.ends_with("'") {
                         Ok(value.to_string())
                     } else {
@@ -101,10 +101,10 @@ impl Tokenization {
                     }
                 }
 
-                _ if column_metadata.column_type == TypeId::of::<i32>() ||
-                     column_metadata.column_type == TypeId::of::<i64>() ||
-                     column_metadata.column_type == TypeId::of::<f32>() ||
-                     column_metadata.column_type == TypeId::of::<f64>() => {
+                _ if column_metadata.column_type() == TypeId::of::<i32>() ||
+                     column_metadata.column_type() == TypeId::of::<i64>() ||
+                     column_metadata.column_type() == TypeId::of::<f32>() ||
+                     column_metadata.column_type() == TypeId::of::<f64>() => {
 
                         value.parse::<f64>().map_or_else(
                         |_| Err(format!("Invalid numeric value: {}", value)),
@@ -112,7 +112,7 @@ impl Tokenization {
                     )
                 }
     
-                _ if column_metadata.column_type == TypeId::of::<bool>() => {
+                _ if column_metadata.column_type() == TypeId::of::<bool>() => {
                     match value.to_lowercase().as_str() {
                         "true" => Ok(String::from("TRUE")),
                         "false" => Ok(String::from("FALSE")),
@@ -120,9 +120,9 @@ impl Tokenization {
                     }
                 }
     
-                _ if column_metadata.column_type == TypeId::of::<String>() ||
-                     column_metadata.column_type == TypeId::of::<NaiveDate>() ||
-                     column_metadata.column_type == TypeId::of::<NaiveDateTime>() => {
+                _ if column_metadata.column_type() == TypeId::of::<String>() ||
+                     column_metadata.column_type() == TypeId::of::<NaiveDate>() ||
+                     column_metadata.column_type() == TypeId::of::<NaiveDateTime>() => {
                     if value.starts_with("'") && value.ends_with("'") {
                         Ok(value.to_string())
                     } else {
@@ -130,7 +130,7 @@ impl Tokenization {
                     }
                 }
     
-                _ => Err(format!("Unsupported column type for {}", column_metadata.column_name)),
+                _ => Err(format!("Unsupported column type for {}", column_metadata.column_name())),
             },
         }
     }
@@ -263,7 +263,7 @@ impl Tokenization {
 
     fn get_operation(column_metadata: &ContextualizerColumnMetadata, tokens_iter: &mut EventfulPeekable<std::slice::Iter<'_, String>>) -> Result<Operation, String> {
 
-        let operator: &str = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {}", column_metadata.column_name))?; 
+        let operator: &str = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {}", column_metadata.column_name()))?; 
 
         Self::validate_operator(operator, column_metadata)?;
 
@@ -283,7 +283,7 @@ impl Tokenization {
             }
             
             if parentheses_depth != 0 {
-                return Err(format!("Unbalanced parentheses in 'in clause': {} : {}", column_metadata.column_name, operator));
+                return Err(format!("Unbalanced parentheses in 'in clause': {} : {}", column_metadata.column_name(), operator));
             }
 
             // [Formatting  and Validation of values]
@@ -296,14 +296,14 @@ impl Tokenization {
             }
 
             if values.len() == 0 {
-                return Err(format!("'in clause' must have values: {} : {}", column_metadata.column_name, operator));
+                return Err(format!("'in clause' must have values: {} : {}", column_metadata.column_name(), operator));
             }
 
             return Ok(Operation::in_values(values))
         }
 
         // [Formatting and Validation of values]
-        let non_formatted_value = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {} : {}", column_metadata.column_name, operator))?;
+        let non_formatted_value = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {} : {}", column_metadata.column_name(), operator))?;
 
         let value: String = Self::format_value(non_formatted_value, column_metadata)?;
 
@@ -315,7 +315,7 @@ impl Tokenization {
             "lt" => Operation::less_than(value),
             "le" => Operation::less_than_or_equal(value),
             "like" => Operation::like(value),
-            _ => return Err(format!("Unsupported operator: {} : {}", column_metadata.column_name, operator)),
+            _ => return Err(format!("Unsupported operator: {} : {}", column_metadata.column_name(), operator)),
         };
         
         Ok(operation)
@@ -326,7 +326,7 @@ impl Tokenization {
             return Err(format!("Operator '{}' is not a valid operator", operator));
         }
 
-        if let Some(valid_operators) = VALID_OPERATORS.get(&column_metadata.column_type) {
+        if let Some(valid_operators) = VALID_OPERATORS.get(&column_metadata.column_type()) {
             if valid_operators.contains(&operator) {
                 return Ok(());
             } else {
@@ -370,7 +370,7 @@ impl Tokenization {
         let mut last_token = LastToken::None;
 
         let error_with_context = |message: String| -> String {
-            format!("Invalid $filter: {} [Context: {}]", message, context.borrow())
+            format!("{} [Context: {}]", message, context.borrow())
         };
     
         while let Some(token) = tokens_iter.next() {

--- a/src/services/query/database/sqlite/operations/orderby/compute/compute.rs
+++ b/src/services/query/database/sqlite/operations/orderby/compute/compute.rs
@@ -1,0 +1,144 @@
+use std::collections::HashMap;
+use lazy_static::lazy_static;
+
+use crate::services::query::common::alias_manager::QueryAliasManager;
+use crate::database::sqlite::common::context::contextualizer::{ContextualizerColumnMetadata, ComputeArithmeticOperation, ComputeOperation, ComputeSpecificationMetadata};
+
+#[derive(Hash, Eq, PartialEq, Debug)]
+enum ArithmeticOperationType {
+    Addition,
+    Subtration,
+    Multiplication,
+    Division,
+    Module
+}
+
+lazy_static! {
+    static ref ARITHMETIC_OPERATORS: HashMap<ArithmeticOperationType, &'static str> = {
+        let mut map = HashMap::new();
+        map.insert(ArithmeticOperationType::Addition, "+");
+        map.insert(ArithmeticOperationType::Subtration, "-");
+        map.insert(ArithmeticOperationType::Multiplication, "*");
+        map.insert(ArithmeticOperationType::Division, "/");
+        map.insert(ArithmeticOperationType::Module, "%");
+        map
+    };
+}
+
+pub struct Compute;
+
+impl Compute {
+    pub fn process_computed_column(
+        column_metadata: &ContextualizerColumnMetadata,
+        properties: &mut Vec<String>,
+        alias_manager: &mut QueryAliasManager,
+    ) -> Result<(), String> {
+
+        match column_metadata {
+            ContextualizerColumnMetadata::Dynamic { specification, .. } => {
+                match &specification.operation_type {
+                    ComputeOperation::Alias { operation } => {
+        
+                        let original_table = alias_manager.get_or_create_table_alias(&operation.table_name);
+                        let original_column_name = &operation.column_name;
+           
+                        properties.push(format!(
+                            "([{}].[{}])", 
+                            original_table, original_column_name
+                        ));
+        
+                    },
+                    ComputeOperation::Arithmetic { operation } => {
+                        let get_arithmetic_operator = |arithmetic_operator_type: &ArithmeticOperationType| -> &'static str {
+                            ARITHMETIC_OPERATORS
+                                .get(arithmetic_operator_type)
+                                .ok_or_else(|| format!("Invalid $compute: Arithmetic operator not found for {:?}", arithmetic_operator_type))
+                                .unwrap()
+                        };
+        
+                        match operation {
+                            ComputeArithmeticOperation::Addition { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Addition);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+        
+       
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}])", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name
+                                ));
+                            },
+                            ComputeArithmeticOperation::Subtration { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Subtration);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+               
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}])", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name
+                                ));
+                            },
+                            ComputeArithmeticOperation::Multiplication { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Multiplication);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+                
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}])", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name
+                                ));
+                            },
+                            ComputeArithmeticOperation::Division { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Division);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+                
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}])", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name
+                                ));
+                            },
+                            ComputeArithmeticOperation::Module { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Module);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+                
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}])", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name
+                                ));
+                            }
+                        }
+                    }
+                }
+            },
+            _ => return Err(String::from("Provide only computed columns to 'process_computed_column'"))
+        }
+        Ok(())
+    }
+}

--- a/src/services/query/database/sqlite/operations/orderby/orderby.rs
+++ b/src/services/query/database/sqlite/operations/orderby/orderby.rs
@@ -1,9 +1,9 @@
 use crate::services::query::common::alias_manager::QueryAliasManager;
 
-use crate::database::sqlite::common::context::contextualizer::ContextualizerMetadata;
+use crate::database::sqlite::common::context::contextualizer::{ContextualizerMetadata, ContextualizerColumnMetadata};
 use crate::services::query::database::sqlite::common::tokens::orderby::token::Token;
 
-use super::token::tokenization::Tokenization;
+use super::{compute::compute::Compute, token::tokenization::Tokenization};
 
 pub struct Orderby;
 
@@ -14,13 +14,23 @@ impl Orderby {
         contextualizer: &ContextualizerMetadata,
     ) -> Result<String, String> {
 
+        let error = |message: String| -> String {
+            format!("Invalid $orderby: {}", message)
+        };
+
         let mut sql: String = String::from("");
         let mut tokens: Vec<Token> = Vec::new();
 
         if let Some(text) = text {
-            tokens = Tokenization::tokenize(text, contextualizer)?;
+            tokens = match Tokenization::tokenize(text, contextualizer) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
 
-            sql = Self::process_with_tokens(&tokens, alias_manager)?;
+            sql = match Self::process_with_tokens(&tokens, alias_manager) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
         }
 
         // [There no changes in context for while...]
@@ -42,12 +52,20 @@ impl Orderby {
         for token in tokens {
             match token {
                 Token::Property { metadata, column_metadata } => {
-                    let table_alias = alias_manager.get_or_create_table_alias(&metadata.table_name);
+                    match column_metadata {
+                        ContextualizerColumnMetadata::Original { column_name, .. } => {
+
+                            let table_alias = alias_manager.get_or_create_table_alias(&metadata.table_name);
                     
-                    properties.push(format!(
-                        "[{}].[{}]",
-                        table_alias, column_metadata.column_name
-                    ));
+                            properties.push(format!(
+                                "[{}].[{}]",
+                                table_alias, column_name
+                            ));
+                        },
+                        ContextualizerColumnMetadata::Dynamic { .. } => { 
+                            Compute::process_computed_column(&column_metadata, &mut properties, alias_manager)?
+                        } 
+                    }
                 },
             }
         }

--- a/src/services/query/database/sqlite/operations/orderby/token/tokenization.rs
+++ b/src/services/query/database/sqlite/operations/orderby/token/tokenization.rs
@@ -130,7 +130,7 @@ impl Tokenization {
         let mut last_token = LastToken::None;
 
         let error_with_context = |message: String| -> String {
-            format!("Invalid $orderby: {} [Context: {}]", message, context.borrow())
+            format!("{} [Context: {}]", message, context.borrow())
         };
     
         while let Some(token) = tokens_iter.next() {

--- a/src/services/query/database/sqlite/operations/select/compute/compute.rs
+++ b/src/services/query/database/sqlite/operations/select/compute/compute.rs
@@ -1,0 +1,155 @@
+use std::collections::HashMap;
+use lazy_static::lazy_static;
+
+use crate::services::query::common::alias_manager::QueryAliasManager;
+use crate::database::sqlite::common::context::contextualizer::{ContextualizerColumnMetadata, ComputeArithmeticOperation, ComputeOperation, ComputeSpecificationMetadata};
+
+#[derive(Hash, Eq, PartialEq, Debug)]
+enum ArithmeticOperationType {
+    Addition,
+    Subtration,
+    Multiplication,
+    Division,
+    Module
+}
+
+lazy_static! {
+    static ref ARITHMETIC_OPERATORS: HashMap<ArithmeticOperationType, &'static str> = {
+        let mut map = HashMap::new();
+        map.insert(ArithmeticOperationType::Addition, "+");
+        map.insert(ArithmeticOperationType::Subtration, "-");
+        map.insert(ArithmeticOperationType::Multiplication, "*");
+        map.insert(ArithmeticOperationType::Division, "/");
+        map.insert(ArithmeticOperationType::Module, "%");
+        map
+    };
+}
+
+pub struct Compute;
+
+impl Compute {
+    pub fn process_computed_column(
+        column_metadata: &ContextualizerColumnMetadata,
+        properties: &mut Vec<String>,
+        alias_manager: &mut QueryAliasManager,
+    ) -> Result<(), String> {
+
+        match column_metadata {
+            ContextualizerColumnMetadata::Dynamic { column_name, specification, .. } => {
+                match &specification.operation_type {
+                    ComputeOperation::Alias { operation } => {
+        
+                        let original_table = alias_manager.get_or_create_table_alias(&operation.table_name);
+                        let original_column_name = &operation.column_name;
+        
+                        let alias_column_name = alias_manager.get_or_create_field_alias(&column_name);
+        
+                        properties.push(format!(
+                            "[{}].[{}] AS [{}]", 
+                            original_table, original_column_name, alias_column_name
+                        ));
+        
+                    },
+                    ComputeOperation::Arithmetic { operation } => {
+                        let get_arithmetic_operator = |arithmetic_operator_type: &ArithmeticOperationType| -> &'static str {
+                            ARITHMETIC_OPERATORS
+                                .get(arithmetic_operator_type)
+                                .ok_or_else(|| format!("Invalid $compute: Arithmetic operator not found for {:?}", arithmetic_operator_type))
+                                .unwrap()
+                        };
+        
+                        match operation {
+                            ComputeArithmeticOperation::Addition { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Addition);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+        
+                                let alias_column_name = alias_manager.get_or_create_field_alias(&column_name);
+        
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}]) AS [{}]", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, alias_column_name
+                                ));
+                            },
+                            ComputeArithmeticOperation::Subtration { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Subtration);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+        
+                                let alias_column_name = alias_manager.get_or_create_field_alias(&column_name);
+        
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}]) AS [{}]", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, alias_column_name
+                                ));
+                            },
+                            ComputeArithmeticOperation::Multiplication { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Multiplication);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+        
+                                let alias_column_name = alias_manager.get_or_create_field_alias(&column_name);
+        
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}]) AS [{}]", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, alias_column_name
+                                ));
+                            },
+                            ComputeArithmeticOperation::Division { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Division);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+        
+                                let alias_column_name = alias_manager.get_or_create_field_alias(&column_name);
+        
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}]) AS [{}]", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, alias_column_name
+                                ));
+                            },
+                            ComputeArithmeticOperation::Module { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Module);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+        
+                                let alias_column_name = alias_manager.get_or_create_field_alias(&column_name);
+        
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}]) AS [{}]", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, alias_column_name
+                                ));
+                            }
+                        }
+                    }
+                }
+            },
+            _ => return Err(String::from("Provide only computed columns to 'process_computed_column'"))
+        }
+        Ok(())
+    }
+}

--- a/src/services/query/database/sqlite/operations/select/select.rs
+++ b/src/services/query/database/sqlite/operations/select/select.rs
@@ -1,9 +1,36 @@
+use std::collections::HashMap;
+
+use lazy_static::lazy_static;
+
 use crate::services::query::common::alias_manager::QueryAliasManager;
 
-use crate::database::sqlite::common::context::contextualizer::ContextualizerMetadata;
+use crate::database::sqlite::common::context::contextualizer::{ComputeArithmeticOperation, ComputeOperation, ContextualizerColumnMetadata, ContextualizerMetadata};
 use crate::services::query::database::sqlite::common::tokens::select::token::Token;
 
+use super::compute::compute::Compute;
 use super::token::tokenization::Tokenization;
+
+#[derive(Hash, Eq, PartialEq, Debug)]
+enum ArithmeticOperationType {
+    Addition,
+    Subtration,
+    Multiplication,
+    Division,
+    Module
+}
+
+lazy_static! {
+    static ref ARITHMETIC_OPERATORS: HashMap<ArithmeticOperationType, &'static str> = {
+        let mut map = HashMap::new();
+        map.insert(ArithmeticOperationType::Addition, "+");
+        map.insert(ArithmeticOperationType::Subtration, "-");
+        map.insert(ArithmeticOperationType::Multiplication, "*");
+        map.insert(ArithmeticOperationType::Division, "/");
+        map.insert(ArithmeticOperationType::Module, "%");
+        map
+    };
+}
+
 
 pub struct Select;
 
@@ -14,16 +41,30 @@ impl Select {
         contextualizer: &ContextualizerMetadata,
     ) -> Result<String, String> {
 
+        let error = |message: String| -> String {
+            format!("Invalid $select: {}", message)
+        };
+
         let mut sql: String = String::from("");
         let mut tokens: Vec<Token> = Vec::new();
 
         if let Some(text) = text {
-            tokens = Tokenization::tokenize(text, contextualizer)?;
 
-            sql = Self::process_with_tokens(&tokens, alias_manager, contextualizer)?;
+            tokens = match Tokenization::tokenize(text, contextualizer) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
+
+            sql = match Self::process_with_tokens(&tokens, alias_manager, contextualizer) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
         }
         else {
-            sql = Self::process_without_tokens(alias_manager, contextualizer)?  
+            sql = match Self::process_without_tokens(alias_manager, contextualizer) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };  
         }
 
         // [There no changes in context for while...]
@@ -47,11 +88,11 @@ impl Select {
         let table_alias: String = alias_manager.get_or_create_table_alias(&metadata.table_name);
 
         for column_metadata in metadata.columns.values() {
-            let field_alias: String = alias_manager.get_or_create_field_alias(&column_metadata.column_name);
+            let field_alias: String = alias_manager.get_or_create_field_alias(&column_metadata.column_name());
             
             properties.push(format!(
                 "[{}].[{}] AS [{}]",
-                table_alias, column_metadata.column_name, field_alias
+                table_alias, column_metadata.column_name(), field_alias
             ));
         }
 
@@ -83,14 +124,22 @@ impl Select {
         for token in tokens {
             match token {
                 Token::Property { metadata, column_metadata, relation_path} => {
-                    let table_alias = alias_manager.get_or_create_table_alias(&metadata.table_name);
-                    let field_alias = alias_manager.get_or_create_field_alias(&relation_path);
-                    
-                    properties.push(format!(
-                        "[{}].[{}] AS [{}]", 
-                        table_alias, column_metadata.column_name, field_alias
-                    ));
-                },
+                    match column_metadata {
+                        ContextualizerColumnMetadata::Original { column_name, .. } => {
+
+                            let table_alias = alias_manager.get_or_create_table_alias(&metadata.table_name);
+                            let field_alias = alias_manager.get_or_create_field_alias(&relation_path);
+                            
+                            properties.push(format!(
+                                "[{}].[{}] AS [{}]", 
+                                table_alias, column_name, field_alias
+                            ));
+                        },
+                        ContextualizerColumnMetadata::Dynamic { .. } => { 
+                            Compute::process_computed_column(&column_metadata, &mut properties, alias_manager)?
+                        } 
+                    }
+                }
             }
         }
 

--- a/src/services/query/database/sqlite/operations/select/token/tokenization.rs
+++ b/src/services/query/database/sqlite/operations/select/token/tokenization.rs
@@ -130,7 +130,7 @@ impl Tokenization {
         let mut last_token = LastToken::None;
 
         let error_with_context = |message: String| -> String {
-            format!("Invalid $select: {} [Context: {}]", message, context.borrow())
+            format!("{} [Context: {}]", message, context.borrow())
         };
     
         while let Some(token) = tokens_iter.next() {

--- a/src/services/query/database/sqlite/query.rs
+++ b/src/services/query/database/sqlite/query.rs
@@ -3,6 +3,7 @@ use crate::dto::query_params::QueryParams;
 
 use crate::database::sqlite::common::context::contextualizer::ContextualizerMetadata;
 
+use crate::services::query::database::sqlite::operations::compute::compute::Compute;
 use crate::services::query::database::sqlite::operations::select::select::Select;
 use crate::services::query::database::sqlite::operations::filter::filter::Filter;
 use crate::services::query::database::sqlite::operations::expand::expand::Expand;
@@ -22,6 +23,9 @@ impl Query {
 
         // [$expand (With context changes)]
         let expand_text = Expand::process(options.expand.as_deref(), query_alias_manager, contextualizer)?;
+
+        // [$compute (With context changes)]
+        Compute::process(options.compute.as_deref(), contextualizer)?;
 
         // [$select (Without context changes)]
         let select_text = Select::process(options.select.as_deref(), query_alias_manager, contextualizer)?;


### PR DESCRIPTION
● Key points:

• Now, we can make arithimetic operations with (add, sub, mul, div, mod) and make alias with column names of database.

• For future, I'll make /$count and $count=true for the queries that need only the count or embedded count with the data.

• Final result of a query using $compute:

SELECT
[t3].[id_context] AS [f1], ([t2].[id_forum] - [t3].[id_context]) AS [f2] FROM
[ForumUserRolePermission] AS [t1]
LEFT JOIN [Forum] AS [t2] ON [t1].[id_forum] = [t2].[id_forum] LEFT JOIN [Context] AS [t3] ON [t2].[id_context] = [t3].[id_context] WHERE
 ([t2].[id_forum] - [t3].[id_context]) = 1
ORDER BY
([t2].[id_forum] - [t3].[id_context]), ([t3].[id_context])

URL:

http://localhost:8900/api/forum-user-role-permission?$filter=eduardo%20eq%201&$select=id_forum_user-role,%20eduardo&$expand=Forum,Forum/Context&$compute=Forum/Context/id_context%20as%20id_forum_user-role,%20Forum/id_forum%20sub%20Forum/Context/id_context%20as%20eduardo&$orderby=eduardo,%20id_forum_user-role