### PR TITLE
▣ Inclusion of $count for only count response queries.

### DIFF
--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -2,21 +2,52 @@ use actix_web::{web, App, HttpServer};
 use crate::database::DatabaseType;
 
 pub fn configure_services(cfg: &mut web::ServiceConfig) {
+
     cfg.service( crate::features::action::controllers::get);
+    cfg.service( crate::features::action::controllers::get_count);
+    
     cfg.service( crate::features::authentication_type::controllers::get);
+    cfg.service( crate::features::authentication_type::controllers::get_count);
+    
     cfg.service( crate::features::context::controllers::get);
+    cfg.service( crate::features::context::controllers::get_count);
+
     cfg.service( crate::features::fork::controllers::get);
+    cfg.service( crate::features::fork::controllers::get_count);
+
     cfg.service( crate::features::forum::controllers::get);
+    cfg.service( crate::features::forum::controllers::get_count);
+
     cfg.service( crate::features::forum_user_role_permission::controllers::get);
+    cfg.service( crate::features::forum_user_role_permission::controllers::get_count);
+
     cfg.service( crate::features::particular::controllers::get);
+    cfg.service( crate::features::particular::controllers::get_count);
+
     cfg.service( crate::features::particular_user_role_permission::controllers::get);
+    cfg.service( crate::features::particular_user_role_permission::controllers::get_count);
+
     cfg.service( crate::features::permission::controllers::get);
+    cfg.service( crate::features::permission::controllers::get_count);
+
     cfg.service( crate::features::relation::controllers::get);
+    cfg.service( crate::features::relation::controllers::get_count);
+
     cfg.service( crate::features::role::controllers::get);
+    cfg.service( crate::features::role::controllers::get_count);
+
     cfg.service( crate::features::topic::controllers::get);
+    cfg.service( crate::features::topic::controllers::get_count);
+
     cfg.service( crate::features::user_authentication_type::controllers::get);
+    cfg.service( crate::features::user_authentication_type::controllers::get_count);
+
     cfg.service( crate::features::user::controllers::get);
+    cfg.service( crate::features::user::controllers::get_count);
+
     cfg.service( crate::features::user_system::controllers::get);
+    cfg.service( crate::features::user_system::controllers::get_count);
+    
 }
 
 pub async fn run(db: DatabaseType) -> std::io::Result<()> {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -31,6 +31,7 @@ pub mod sqlite {
 
 pub trait Database {
     async fn execute<T: EntityMetadata>(&self, options: &QueryParams) -> Result<Vec<Value>, String>;
+    async fn execute_count<T: EntityMetadata>(&self, options: &QueryParams) -> Result<Value, String>;
 }
 
 pub enum DatabaseType {
@@ -52,6 +53,13 @@ impl Database for DatabaseType {
         match self {
             DatabaseType::Mssql(db) => db.execute::<T>(options).await,
             DatabaseType::Sqlite(db) => db.execute::<T>(options).await
+        }
+    }
+
+    async fn execute_count<T: EntityMetadata>(&self, options: &QueryParams) -> Result<Value, String>  {
+        match self {
+            DatabaseType::Mssql(db) => db.execute_count::<T>(options).await,
+            DatabaseType::Sqlite(db) => db.execute_count::<T>(options).await
         }
     }
 }

--- a/src/database/mssql/common/context/contextualizer.rs
+++ b/src/database/mssql/common/context/contextualizer.rs
@@ -10,10 +10,10 @@ pub struct ContextualizerMetadata {
 impl ContextualizerMetadata {
     pub fn new(metadata: EntityDescription) -> Self {
         let columns = metadata.columns.into_iter().map(|(k, v)| {
-            (k, ContextualizerColumnMetadata {
-                column_name: v.column_name,
-                column_type: v.column_type,
-            })
+            (k, ContextualizerColumnMetadata::new( 
+                v.column_name,
+                v.column_type,
+            ))
         }).collect::<HashMap<_, _>>();
 
         let relationships = metadata.relationships.into_iter().map(|(k, v)| {
@@ -40,10 +40,10 @@ impl ContextualizerMetadata {
 
 fn convert_to_contextualizer_entity(entity: &EntityDescription) -> ContextualizerEntityDescription {
     let columns = entity.columns.iter().map(|(k, v)| {
-        (k.clone(), ContextualizerColumnMetadata {
-            column_name: v.column_name.clone(),
-            column_type: v.column_type,
-        })
+        (k.clone(), ContextualizerColumnMetadata::new(
+            v.column_name.to_string(), 
+            v.column_type
+        ))
     }).collect::<HashMap<_, _>>();
 
     let relationships = entity.relationships.iter().map(|(k, v)| {
@@ -77,19 +77,105 @@ fn convert_to_contextualizer_relationship_type(relationship_type: &RelationshipT
 }
 
 #[derive(Debug, Clone)]
-pub struct ContextualizerColumnMetadata {
+pub enum ContextualizerColumnMetadata {
+    Original {
+        column_name: String,
+        column_type: TypeId,
+    },
+    Dynamic {
+        column_name: String,
+        column_type: TypeId,
+        specification: ComputeSpecificationMetadata
+    },
+}
+
+// [Compute Specification] //
+
+#[derive(Debug, Clone)]
+pub struct ComputeSpecificationMetadata {
+    pub operation_type: ComputeOperation
+}
+
+#[derive(Debug, Clone)]
+pub enum ComputeOperation {
+    Arithmetic {
+        operation: ComputeArithmeticOperation
+    },
+    Alias {
+        operation: ComputeAliasOperation
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ComputeOperand {
+    pub table_name: String,
     pub column_name: String,
-    pub column_type: TypeId,
+}
+
+#[derive(Debug, Clone)]
+pub enum ComputeArithmeticOperation {
+    Addition {
+        left_operand: ComputeOperand,
+        right_operand: ComputeOperand
+    },
+    Subtration {
+        left_operand: ComputeOperand,
+        right_operand: ComputeOperand
+    },
+    Multiplication {
+        left_operand: ComputeOperand,
+        right_operand: ComputeOperand
+    },
+    Division {
+        left_operand: ComputeOperand,
+        right_operand: ComputeOperand
+    },
+    Module {
+        left_operand: ComputeOperand,
+        right_operand: ComputeOperand
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ComputeAliasOperation {
+    pub table_name: String,
+    pub column_name: String
+}
+
+// [Compute Specification] //
+
+impl ContextualizerColumnMetadata {
+    pub fn new(column_name: String, column_type: TypeId) -> Self {
+        ContextualizerColumnMetadata::Original {
+            column_name,
+            column_type,
+        }
+    }
+
+    pub fn column_name(&self) -> &String {
+        match self {
+            ContextualizerColumnMetadata::Original { column_name, .. } => column_name,
+            ContextualizerColumnMetadata::Dynamic { column_name, .. } => column_name,
+        }
+    }
+
+    pub fn column_type(&self) -> TypeId {
+        match self {
+            ContextualizerColumnMetadata::Original { column_type, .. } => *column_type,
+            ContextualizerColumnMetadata::Dynamic { column_type, .. } => *column_type,
+        }
+    }
 }
 
 impl Default for ContextualizerColumnMetadata {
     fn default() -> Self {
-        ContextualizerColumnMetadata {
+        ContextualizerColumnMetadata::Original {
             column_name: "".to_string(),
             column_type: TypeId::of::<String>(),
         }
     }
-}
+}   
+
 
 #[derive(Debug, Clone)]
 pub enum ContextualizerRelationshipType {

--- a/src/database/mssql/database.rs
+++ b/src/database/mssql/database.rs
@@ -43,6 +43,31 @@ impl crate::database::Database for Database {
     
         Ok(results)
     }
+
+    async fn execute_count<T: EntityMetadata>(&self, options: &QueryParams) -> Result<Value, String> {   
+        
+        let mut contextualizer = ContextualizerMetadata::new(T::metadata().clone());
+
+        let mut alias_manger = QueryAliasManager::new();
+
+        let query = Query.build_query_count(options, &mut alias_manger, &mut contextualizer)?;
+        
+        let rows = sqlx::query(&query)
+            .fetch_all(&self.0)
+            .await
+            .map_err(|e| format!("Error executing query: {}", e))?;
+
+        if rows.is_empty() {
+            return Err("No rows returned from query".to_string());
+        }
+
+        let properties_hierarchy = Self::parse_properties_hierarchy(&rows, &alias_manger, &mut contextualizer);
+    
+        let mut json_row = Map::new();
+        Self::parse_and_populate_fields(&rows[0], &properties_hierarchy, &mut json_row);
+
+        Ok(Value::Object(json_row))
+    }
     
 }
 
@@ -163,11 +188,11 @@ impl Database {
                     // [Parsed Metadata | The name of metadata will not the same for database]
                     let parsed_metadata = ColumnMetadata {
                         column_name: key.to_string(),
-                        column_type: metadata.column_type
+                        column_type: metadata.column_type()
                     };
 
                     if let Some(value) = Self::fetch_column_value(row, &parsed_metadata) {
-                        json_row.insert(metadata.column_name.to_string(), value);
+                        json_row.insert(metadata.column_name().to_string(), value);
                     }
                 }
                 PropertyType::RelationalProperty { properties, .. } => { 
@@ -202,11 +227,11 @@ impl Database {
                     // [Parsed Metadata | The name of metadata will not the same for database]
                     let parsed_metadata = ColumnMetadata {
                         column_name: key.to_string(),
-                        column_type: metadata.column_type
+                        column_type: metadata.column_type()
                     };
 
                     if let Some(value) = Self::fetch_column_value(row, &parsed_metadata) {
-                        json_row.insert(metadata.column_name.to_string(), value);
+                        json_row.insert(metadata.column_name().to_string(), value);
                     }
                 }
                 PropertyType::RelationalProperty { properties, .. } => {

--- a/src/database/sqlite/common/context/contextualizer.rs
+++ b/src/database/sqlite/common/context/contextualizer.rs
@@ -152,7 +152,7 @@ impl ContextualizerColumnMetadata {
         }
     }
 
-    pub fn new_dynamically(column_name: String, column_type: TypeId, specification: ComputeSpecificationMetadata) -> Self {
+    pub fn new_dynamic(column_name: String, column_type: TypeId, specification: ComputeSpecificationMetadata) -> Self {
         ContextualizerColumnMetadata::Dynamic {
             column_name,
             column_type,

--- a/src/database/sqlite/database.rs
+++ b/src/database/sqlite/database.rs
@@ -15,8 +15,7 @@ use super::common::context::{contextualizer::ContextualizerMetadata, mapping::me
 pub struct Database(pub SqlitePool);
 
 impl crate::database::Database for Database {
-    async fn execute<T: EntityMetadata>(&self, options: &QueryParams) -> Result<Vec<Value>, String> {   
-        
+    async fn execute<T: EntityMetadata>(&self, options: &QueryParams) -> Result<Vec<Value>, String> {      
         let mut contextualizer = ContextualizerMetadata::new(T::metadata().clone());
 
         let mut alias_manger = QueryAliasManager::new();
@@ -43,7 +42,31 @@ impl crate::database::Database for Database {
     
         Ok(results)
     }
+
+    async fn execute_count<T: EntityMetadata>(&self, options: &QueryParams) -> Result<Value, String> {   
+        let mut contextualizer = ContextualizerMetadata::new(T::metadata().clone());
+
+        let mut alias_manger = QueryAliasManager::new();
+
+        let query = Query.build_query_count(options, &mut alias_manger, &mut contextualizer)?;
+        
+        let rows = sqlx::query(&query)
+            .fetch_all(&self.0)
+            .await
+            .map_err(|e| format!("Error executing query: {}", e))?;
+
+        if rows.is_empty() {
+            return Err("No rows returned from query".to_string());
+        }
+
+        let properties_hierarchy = Self::parse_properties_hierarchy(&rows, &alias_manger, &mut contextualizer);
+
+        let mut json_row = Map::new();
+        Self::parse_and_populate_fields(&rows[0], &properties_hierarchy, &mut json_row);
+
+        Ok(Value::Object(json_row))
     
+    }
 }
 
 impl Database {

--- a/src/dto/metadata.rs
+++ b/src/dto/metadata.rs
@@ -27,8 +27,6 @@ pub enum RelationshipType {
 #[derive(Debug, Clone)]
 pub struct RelationshipMetadata {
     pub related_entity_metadata: EntityDescription,
-    pub related_entity: String,
-    pub navigation_property: String,
     pub relationship_type: RelationshipType,
     pub foreign_keys: Vec<String>,
     pub related_keys: Vec<String>,

--- a/src/features/action/controllers.rs
+++ b/src/features/action/controllers.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, web, Responder, HttpResponse};
-use crate::features::action::services::ActionService;
+use crate::features::action::services::Service;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
@@ -8,7 +8,23 @@ pub async fn get(
     options: web::Query<QueryParams>,
     db: web::Data<DatabaseType>,
 ) -> impl Responder {
-    let result = ActionService::get(&*db, options.into_inner()).await;
+    let result = Service::get(&*db, options.into_inner()).await;
+
+    match result {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(err) => {
+            let error_message = format!("Error: {}", err);
+            HttpResponse::BadRequest().body(error_message)
+        }
+    }
+}
+
+#[get("/api/action/$count")]
+pub async fn get_count(
+    options: web::Query<QueryParams>,
+    db: web::Data<DatabaseType>,
+) -> impl Responder {
+    let result = Service::get_count(&*db, options.into_inner()).await;
 
     match result {
         Ok(data) => HttpResponse::Ok().json(data),

--- a/src/features/action/models.rs
+++ b/src/features/action/models.rs
@@ -2,10 +2,10 @@ use chrono::{NaiveDateTime, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::any::TypeId;
-use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::{relation::models::RelationModel, topic::models::TopicModel, user::models::UserModel}};
+use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::{relation::models::Model as RelationModel, topic::models::Model as TopicModel, user::models::Model as UserModel}};
 
 #[derive(Serialize, Deserialize)]
-pub struct ActionModel {
+pub struct Model {
     pub id_action: i32,
     pub date_action: NaiveDateTime,
     pub id_user: Option<i32>,
@@ -13,9 +13,9 @@ pub struct ActionModel {
     pub id_topic: Option<i32>
 }
 
-impl Default for ActionModel {
+impl Default for Model {
     fn default() -> Self {
-        ActionModel {
+        Model {
             id_action: 0,
             date_action: Utc.with_ymd_and_hms(0,0,0,0,0,0).unwrap().naive_local(),
             id_user: None,
@@ -25,7 +25,7 @@ impl Default for ActionModel {
     }
 }
 
-impl EntityMetadata for ActionModel {
+impl EntityMetadata for Model {
     fn metadata() -> &'static EntityDescription {
         lazy_static::lazy_static! {
             static ref METADATA: EntityDescription = {
@@ -76,11 +76,9 @@ impl EntityMetadata for ActionModel {
                     "User".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: UserModel::metadata().clone(),
-                        related_entity: "User".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_user".to_string()],
                         related_keys: vec!["id_user".to_string()],
-                        navigation_property: "User".to_string(),
                     },
                 );
 
@@ -88,11 +86,9 @@ impl EntityMetadata for ActionModel {
                     "Relation".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: RelationModel::metadata().clone(),
-                        related_entity: "Relation".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_relation".to_string()],
                         related_keys: vec!["id_relation".to_string()],
-                        navigation_property: "Relation".to_string(),
                     },
                 );
 
@@ -100,11 +96,9 @@ impl EntityMetadata for ActionModel {
                     "Topic".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: TopicModel::metadata().clone(),
-                        related_entity: "Topic".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_topic".to_string()],
                         related_keys: vec!["id_topic".to_string()],
-                        navigation_property: "Topic".to_string(),
                     },
                 );
 

--- a/src/features/action/repositories.rs
+++ b/src/features/action/repositories.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-use crate::features::action::models::ActionModel;
+use crate::features::action::models::Model;
 use crate::dto::query_params::QueryParams;
 use crate::database::{Database, DatabaseType};
 
-pub struct ActionRepository;
+pub struct Repository;
 
-impl ActionRepository {
+impl Repository {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
@@ -14,10 +14,25 @@ impl ActionRepository {
         
         match db {
             DatabaseType::Mssql(mssql_db) => {
-                mssql_db.execute::<ActionModel>(&options).await.map_err(|e| e.to_string())
+                mssql_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
             }
             DatabaseType::Sqlite(sqlite_db) => {
-                sqlite_db.execute::<ActionModel>(&options).await.map_err(|e| e.to_string())
+                sqlite_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+        }
+    }
+
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        match db {
+            DatabaseType::Mssql(mssql_db) => {
+                mssql_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+            DatabaseType::Sqlite(sqlite_db) => {
+                sqlite_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
             }
         }
     }

--- a/src/features/action/services.rs
+++ b/src/features/action/services.rs
@@ -1,16 +1,24 @@
 use serde_json::Value;
-use crate::features::action::repositories::ActionRepository;
+use crate::features::action::repositories::Repository;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
-pub struct ActionService;
+pub struct Service;
 
-impl ActionService {
+impl Service {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
     ) -> Result<Vec<Value>, String> {
         
-        ActionRepository::get(db, options).await
+        Repository::get(db, options).await
+    }
+
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        Repository::get_count(db, options).await
     }
 }

--- a/src/features/authentication_type/controllers.rs
+++ b/src/features/authentication_type/controllers.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, web, Responder, HttpResponse};
-use crate::features::authentication_type::services::AuthenticationTypeService;
+use crate::features::authentication_type::services::Service;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
@@ -8,7 +8,23 @@ pub async fn get(
     options: web::Query<QueryParams>,
     db: web::Data<DatabaseType>,
 ) -> impl Responder {
-    let result = AuthenticationTypeService::get(&*db, options.into_inner()).await;
+    let result = Service::get(&*db, options.into_inner()).await;
+
+    match result {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(err) => {
+            let error_message = format!("Error: {}", err);
+            HttpResponse::BadRequest().body(error_message)
+        }
+    }
+}
+
+#[get("/api/authentication-type/$count")]
+pub async fn get_count(
+    options: web::Query<QueryParams>,
+    db: web::Data<DatabaseType>,
+) -> impl Responder {
+    let result = Service::get_count(&*db, options.into_inner()).await;
 
     match result {
         Ok(data) => HttpResponse::Ok().json(data),

--- a/src/features/authentication_type/models.rs
+++ b/src/features/authentication_type/models.rs
@@ -4,22 +4,22 @@ use std::any::TypeId;
 use crate::dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata};
 
 #[derive(Serialize, Deserialize)]
-pub struct AuthenticationTypeModel {
+pub struct Model {
     pub id_authentication_type: i32,
     pub name_authentication_type: String
 
 }
 
-impl Default for AuthenticationTypeModel {
+impl Default for Model {
     fn default() -> Self {
-        AuthenticationTypeModel {
+        Model {
             id_authentication_type: 0,
             name_authentication_type: "".to_string()
         }
     }
 }
 
-impl EntityMetadata for AuthenticationTypeModel {
+impl EntityMetadata for Model {
     fn metadata() -> &'static EntityDescription {
         lazy_static::lazy_static! {
             static ref METADATA: EntityDescription = {

--- a/src/features/authentication_type/repositories.rs
+++ b/src/features/authentication_type/repositories.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-use crate::features::authentication_type::models::AuthenticationTypeModel;
+use crate::features::authentication_type::models::Model;
 use crate::dto::query_params::QueryParams;
 use crate::database::{Database, DatabaseType};
 
-pub struct AuthenticationTypeRepository;
+pub struct Repository;
 
-impl AuthenticationTypeRepository {
+impl Repository {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
@@ -14,10 +14,25 @@ impl AuthenticationTypeRepository {
         
         match db {
             DatabaseType::Mssql(mssql_db) => {
-                mssql_db.execute::<AuthenticationTypeModel>(&options).await.map_err(|e| e.to_string())
+                mssql_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
             }
             DatabaseType::Sqlite(sqlite_db) => {
-                sqlite_db.execute::<AuthenticationTypeModel>(&options).await.map_err(|e| e.to_string())
+                sqlite_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+        }
+    }
+    
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        match db {
+            DatabaseType::Mssql(mssql_db) => {
+                mssql_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+            DatabaseType::Sqlite(sqlite_db) => {
+                sqlite_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
             }
         }
     }

--- a/src/features/authentication_type/services.rs
+++ b/src/features/authentication_type/services.rs
@@ -1,16 +1,24 @@
 use serde_json::Value;
-use crate::features::authentication_type::repositories::AuthenticationTypeRepository;
+use crate::features::authentication_type::repositories::Repository;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
-pub struct AuthenticationTypeService;
+pub struct Service;
 
-impl AuthenticationTypeService {
+impl Service {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
     ) -> Result<Vec<Value>, String> {
         
-        AuthenticationTypeRepository::get(db, options).await
+        Repository::get(db, options).await
+    }
+    
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        Repository::get_count(db, options).await
     }
 }

--- a/src/features/context/controllers.rs
+++ b/src/features/context/controllers.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, web, Responder, HttpResponse};
-use crate::features::context::services::ContextService;
+use crate::features::context::services::Service;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
@@ -8,7 +8,23 @@ pub async fn get(
     options: web::Query<QueryParams>,
     db: web::Data<DatabaseType>,
 ) -> impl Responder {
-    let result = ContextService::get(&*db, options.into_inner()).await;
+    let result = Service::get(&*db, options.into_inner()).await;
+
+    match result {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(err) => {
+            let error_message = format!("Error: {}", err);
+            HttpResponse::BadRequest().body(error_message)
+        }
+    }
+}
+
+#[get("/api/context/$count")]
+pub async fn get_count(
+    options: web::Query<QueryParams>,
+    db: web::Data<DatabaseType>,
+) -> impl Responder {
+    let result = Service::get_count(&*db, options.into_inner()).await;
 
     match result {
         Ok(data) => HttpResponse::Ok().json(data),

--- a/src/features/context/models.rs
+++ b/src/features/context/models.rs
@@ -4,22 +4,22 @@ use std::any::TypeId;
 use crate::dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata};
 
 #[derive(Serialize, Deserialize)]
-pub struct ContextModel {
+pub struct Model {
     pub id_context: i32,
     pub name_context: String
 
 }
 
-impl Default for ContextModel {
+impl Default for Model {
     fn default() -> Self {
-        ContextModel {
+        Model {
             id_context: 0,
             name_context: "".to_string()
         }
     }
 }
 
-impl EntityMetadata for ContextModel {
+impl EntityMetadata for Model {
     fn metadata() -> &'static EntityDescription {
         lazy_static::lazy_static! {
             static ref METADATA: EntityDescription = {

--- a/src/features/context/repositories.rs
+++ b/src/features/context/repositories.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-use crate::features::context::models::ContextModel;
+use crate::features::context::models::Model;
 use crate::dto::query_params::QueryParams;
 use crate::database::{Database, DatabaseType};
 
-pub struct ContextRepository;
+pub struct Repository;
 
-impl ContextRepository {
+impl Repository {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
@@ -14,10 +14,25 @@ impl ContextRepository {
         
         match db {
             DatabaseType::Mssql(mssql_db) => {
-                mssql_db.execute::<ContextModel>(&options).await.map_err(|e| e.to_string())
+                mssql_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
             }
             DatabaseType::Sqlite(sqlite_db) => {
-                sqlite_db.execute::<ContextModel>(&options).await.map_err(|e| e.to_string())
+                sqlite_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+        }
+    }
+    
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        match db {
+            DatabaseType::Mssql(mssql_db) => {
+                mssql_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+            DatabaseType::Sqlite(sqlite_db) => {
+                sqlite_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
             }
         }
     }

--- a/src/features/context/services.rs
+++ b/src/features/context/services.rs
@@ -1,16 +1,24 @@
 use serde_json::Value;
-use crate::features::context::repositories::ContextRepository;
+use crate::features::context::repositories::Repository;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
-pub struct ContextService;
+pub struct Service;
 
-impl ContextService {
+impl Service {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
     ) -> Result<Vec<Value>, String> {
         
-        ContextRepository::get(db, options).await
+        Repository::get(db, options).await
+    }
+    
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        Repository::get_count(db, options).await
     }
 }

--- a/src/features/fork/controllers.rs
+++ b/src/features/fork/controllers.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, web, Responder, HttpResponse};
-use crate::features::fork::services::ForkService;
+use crate::features::fork::services::Service;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
@@ -8,7 +8,23 @@ pub async fn get(
     options: web::Query<QueryParams>,
     db: web::Data<DatabaseType>,
 ) -> impl Responder {
-    let result = ForkService::get(&*db, options.into_inner()).await;
+    let result = Service::get(&*db, options.into_inner()).await;
+
+    match result {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(err) => {
+            let error_message = format!("Error: {}", err);
+            HttpResponse::BadRequest().body(error_message)
+        }
+    }
+}
+
+#[get("/api/fork/$count")]
+pub async fn get_count(
+    options: web::Query<QueryParams>,
+    db: web::Data<DatabaseType>,
+) -> impl Responder {
+    let result = Service::get_count(&*db, options.into_inner()).await;
 
     match result {
         Ok(data) => HttpResponse::Ok().json(data),

--- a/src/features/fork/models.rs
+++ b/src/features/fork/models.rs
@@ -1,18 +1,18 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::any::TypeId;
-use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::{action::models::ActionModel, topic::models::TopicModel}};
+use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::{action::models::Model as ActionModel, topic::models::Model as TopicModel}};
 
 #[derive(Serialize, Deserialize)]
-pub struct ForkModel {
+pub struct Model {
     pub id_fork: i32,
     pub id_action: Option<i32>,
     pub id_topic: Option<i32>
 }
 
-impl Default for ForkModel {
+impl Default for Model {
     fn default() -> Self {
-        ForkModel {
+        Model {
             id_fork: 0,
             id_action: None,
             id_topic: None
@@ -20,7 +20,7 @@ impl Default for ForkModel {
     }
 }
 
-impl EntityMetadata for ForkModel {
+impl EntityMetadata for Model {
     fn metadata() -> &'static EntityDescription {
         lazy_static::lazy_static! {
             static ref METADATA: EntityDescription = {
@@ -55,11 +55,9 @@ impl EntityMetadata for ForkModel {
                     "Action".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: ActionModel::metadata().clone(),
-                        related_entity: "Action".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_action".to_string()],
                         related_keys: vec!["id_action".to_string()],
-                        navigation_property: "Action".to_string(),
                     },
                 );
 
@@ -67,11 +65,9 @@ impl EntityMetadata for ForkModel {
                     "Topic".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: TopicModel::metadata().clone(),
-                        related_entity: "Topic".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_topic".to_string()],
                         related_keys: vec!["id_topic".to_string()],
-                        navigation_property: "Topic".to_string(),
                     },
                 );
 

--- a/src/features/fork/repositories.rs
+++ b/src/features/fork/repositories.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-use crate::features::fork::models::ForkModel;
+use crate::features::fork::models::Model;
 use crate::dto::query_params::QueryParams;
 use crate::database::{Database, DatabaseType};
 
-pub struct ForkRepository;
+pub struct Repository;
 
-impl ForkRepository {
+impl Repository {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
@@ -14,10 +14,25 @@ impl ForkRepository {
         
         match db {
             DatabaseType::Mssql(mssql_db) => {
-                mssql_db.execute::<ForkModel>(&options).await.map_err(|e| e.to_string())
+                mssql_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
             }
             DatabaseType::Sqlite(sqlite_db) => {
-                sqlite_db.execute::<ForkModel>(&options).await.map_err(|e| e.to_string())
+                sqlite_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+        }
+    }
+     
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        match db {
+            DatabaseType::Mssql(mssql_db) => {
+                mssql_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+            DatabaseType::Sqlite(sqlite_db) => {
+                sqlite_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
             }
         }
     }

--- a/src/features/fork/services.rs
+++ b/src/features/fork/services.rs
@@ -1,16 +1,24 @@
 use serde_json::Value;
-use crate::features::fork::repositories::ForkRepository;
+use crate::features::fork::repositories::Repository;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
-pub struct ForkService;
+pub struct Service;
 
-impl ForkService {
+impl Service {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
     ) -> Result<Vec<Value>, String> {
         
-        ForkRepository::get(db, options).await
+        Repository::get(db, options).await
+    }
+        
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        Repository::get_count(db, options).await
     }
 }

--- a/src/features/forum/controllers.rs
+++ b/src/features/forum/controllers.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, web, Responder, HttpResponse};
-use crate::features::forum::services::ForumService;
+use crate::features::forum::services::Service;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
@@ -8,7 +8,23 @@ pub async fn get(
     options: web::Query<QueryParams>,
     db: web::Data<DatabaseType>,
 ) -> impl Responder {
-    let result = ForumService::get(&*db, options.into_inner()).await;
+    let result = Service::get(&*db, options.into_inner()).await;
+
+    match result {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(err) => {
+            let error_message = format!("Error: {}", err);
+            HttpResponse::BadRequest().body(error_message)
+        }
+    }
+}
+
+#[get("/api/forum/$count")]
+pub async fn get_count(
+    options: web::Query<QueryParams>,
+    db: web::Data<DatabaseType>,
+) -> impl Responder {
+    let result = Service::get_count(&*db, options.into_inner()).await;
 
     match result {
         Ok(data) => HttpResponse::Ok().json(data),

--- a/src/features/forum/models.rs
+++ b/src/features/forum/models.rs
@@ -1,19 +1,19 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::any::TypeId;
-use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::context::models::ContextModel};
+use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::context::models::Model as ContextModel};
 
 #[derive(Serialize, Deserialize)]
-pub struct ForumModel {
+pub struct Model {
     pub id_forum: i32,
     pub name_forum : String,
     pub description_forum : String,
     pub id_context: Option<i32>
 }
 
-impl Default for ForumModel {
+impl Default for Model {
     fn default() -> Self {
-        ForumModel {
+        Model {
             id_forum: 0,
             name_forum : "".to_string(),
             description_forum : "".to_string(),
@@ -22,7 +22,7 @@ impl Default for ForumModel {
     }
 }
 
-impl EntityMetadata for ForumModel {
+impl EntityMetadata for Model {
     fn metadata() -> &'static EntityDescription {
         lazy_static::lazy_static! {
             static ref METADATA: EntityDescription = {
@@ -64,11 +64,9 @@ impl EntityMetadata for ForumModel {
                     "Context".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: ContextModel::metadata().clone(),
-                        related_entity: "Context".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_context".to_string()],
                         related_keys: vec!["id_context".to_string()],
-                        navigation_property: "Context".to_string(),
                     },
                 );
 

--- a/src/features/forum/repositories.rs
+++ b/src/features/forum/repositories.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-use crate::features::forum::models::ForumModel;
+use crate::features::forum::models::Model;
 use crate::dto::query_params::QueryParams;
 use crate::database::{Database, DatabaseType};
 
-pub struct ForumRepository;
+pub struct Repository;
 
-impl ForumRepository {
+impl Repository {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
@@ -14,10 +14,25 @@ impl ForumRepository {
         
         match db {
             DatabaseType::Mssql(mssql_db) => {
-                mssql_db.execute::<ForumModel>(&options).await.map_err(|e| e.to_string())
+                mssql_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
             }
             DatabaseType::Sqlite(sqlite_db) => {
-                sqlite_db.execute::<ForumModel>(&options).await.map_err(|e| e.to_string())
+                sqlite_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+        }
+    }
+         
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        match db {
+            DatabaseType::Mssql(mssql_db) => {
+                mssql_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+            DatabaseType::Sqlite(sqlite_db) => {
+                sqlite_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
             }
         }
     }

--- a/src/features/forum/services.rs
+++ b/src/features/forum/services.rs
@@ -1,16 +1,24 @@
 use serde_json::Value;
-use crate::features::forum::repositories::ForumRepository;
+use crate::features::forum::repositories::Repository;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
-pub struct ForumService;
+pub struct Service;
 
-impl ForumService {
+impl Service {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
     ) -> Result<Vec<Value>, String> {
         
-        ForumRepository::get(db, options).await
+        Repository::get(db, options).await
+    }
+            
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        Repository::get_count(db, options).await
     }
 }

--- a/src/features/forum_user_role_permission/controllers.rs
+++ b/src/features/forum_user_role_permission/controllers.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, web, Responder, HttpResponse};
-use crate::features::forum_user_role_permission::services::ForumUserRolePermissionService;
+use crate::features::forum_user_role_permission::services::Service;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
@@ -8,7 +8,23 @@ pub async fn get(
     options: web::Query<QueryParams>,
     db: web::Data<DatabaseType>,
 ) -> impl Responder {
-    let result = ForumUserRolePermissionService::get(&*db, options.into_inner()).await;
+    let result = Service::get(&*db, options.into_inner()).await;
+
+    match result {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(err) => {
+            let error_message = format!("Error: {}", err);
+            HttpResponse::BadRequest().body(error_message)
+        }
+    }
+}
+
+#[get("/api/forum-user-role-permission/$count")]
+pub async fn get_count(
+    options: web::Query<QueryParams>,
+    db: web::Data<DatabaseType>,
+) -> impl Responder {
+    let result = Service::get_count(&*db, options.into_inner()).await;
 
     match result {
         Ok(data) => HttpResponse::Ok().json(data),

--- a/src/features/forum_user_role_permission/models.rs
+++ b/src/features/forum_user_role_permission/models.rs
@@ -1,10 +1,10 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::any::TypeId;
-use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::{forum::models::ForumModel, permission::models::PermissionModel, role::models::RoleModel, user::models::UserModel}};
+use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::{forum::models::Model as ForumModel, permission::models::Model as PermissionModel, role::models::Model as RoleModel, user::models::Model as UserModel}};
 
 #[derive(Serialize, Deserialize)]
-pub struct ForumUserRolePermissionModel {
+pub struct Model {
     pub id_forum_user_role_permission: i32,
     pub id_forum: Option<i32>,
     pub id_user: Option<i32>,
@@ -12,9 +12,9 @@ pub struct ForumUserRolePermissionModel {
     pub id_permission: Option<i32>
 }
 
-impl Default for ForumUserRolePermissionModel {
+impl Default for Model {
     fn default() -> Self {
-        ForumUserRolePermissionModel {
+        Model {
             id_forum_user_role_permission: 0,
             id_forum: None,
             id_user: None,
@@ -24,7 +24,7 @@ impl Default for ForumUserRolePermissionModel {
     }
 }
 
-impl EntityMetadata for ForumUserRolePermissionModel {
+impl EntityMetadata for Model {
     fn metadata() -> &'static EntityDescription {
         lazy_static::lazy_static! {
             static ref METADATA: EntityDescription = {
@@ -74,11 +74,9 @@ impl EntityMetadata for ForumUserRolePermissionModel {
                     "Forum".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: ForumModel::metadata().clone(),
-                        related_entity: "Forum".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_forum".to_string()],
                         related_keys: vec!["id_forum".to_string()],
-                        navigation_property: "Forum".to_string(),
                     },
                 );
 
@@ -86,11 +84,9 @@ impl EntityMetadata for ForumUserRolePermissionModel {
                     "User".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: UserModel::metadata().clone(),
-                        related_entity: "User".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_user".to_string()],
                         related_keys: vec!["id_user".to_string()],
-                        navigation_property: "User".to_string(),
                     },
                 );
 
@@ -98,11 +94,9 @@ impl EntityMetadata for ForumUserRolePermissionModel {
                     "Role".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: RoleModel::metadata().clone(),
-                        related_entity: "Role".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_role".to_string()],
                         related_keys: vec!["id_role".to_string()],
-                        navigation_property: "Role".to_string(),
                     },
                 );
 
@@ -110,11 +104,9 @@ impl EntityMetadata for ForumUserRolePermissionModel {
                     "Permission".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: PermissionModel::metadata().clone(),
-                        related_entity: "Permission".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_permission".to_string()],
-                        related_keys: vec!["id_permission".to_string()],
-                        navigation_property: "Permission".to_string(),
+                        related_keys: vec!["id_permission".to_string()]
                     },
                 );
 

--- a/src/features/forum_user_role_permission/repositories.rs
+++ b/src/features/forum_user_role_permission/repositories.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-use crate::features::forum_user_role_permission::models::ForumUserRolePermissionModel;
+use crate::features::forum_user_role_permission::models::Model;
 use crate::dto::query_params::QueryParams;
 use crate::database::{Database, DatabaseType};
 
-pub struct ForumUserRolePermissionRepository;
+pub struct Repository;
 
-impl ForumUserRolePermissionRepository {
+impl Repository {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
@@ -14,10 +14,25 @@ impl ForumUserRolePermissionRepository {
         
         match db {
             DatabaseType::Mssql(mssql_db) => {
-                mssql_db.execute::<ForumUserRolePermissionModel>(&options).await.map_err(|e| e.to_string())
+                mssql_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
             }
             DatabaseType::Sqlite(sqlite_db) => {
-                sqlite_db.execute::<ForumUserRolePermissionModel>(&options).await.map_err(|e| e.to_string())
+                sqlite_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+        }
+    }
+             
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        match db {
+            DatabaseType::Mssql(mssql_db) => {
+                mssql_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+            DatabaseType::Sqlite(sqlite_db) => {
+                sqlite_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
             }
         }
     }

--- a/src/features/forum_user_role_permission/services.rs
+++ b/src/features/forum_user_role_permission/services.rs
@@ -1,16 +1,24 @@
 use serde_json::Value;
-use crate::features::forum_user_role_permission::repositories::ForumUserRolePermissionRepository;
+use crate::features::forum_user_role_permission::repositories::Repository;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
-pub struct ForumUserRolePermissionService;
+pub struct Service;
 
-impl ForumUserRolePermissionService {
+impl Service {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
     ) -> Result<Vec<Value>, String> {
         
-        ForumUserRolePermissionRepository::get(db, options).await
+        Repository::get(db, options).await
+    }
+             
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        Repository::get_count(db, options).await
     }
 }

--- a/src/features/particular/controllers.rs
+++ b/src/features/particular/controllers.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, web, Responder, HttpResponse};
-use crate::features::particular::services::ParticularService;
+use crate::features::particular::services::Service;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
@@ -8,7 +8,23 @@ pub async fn get(
     options: web::Query<QueryParams>,
     db: web::Data<DatabaseType>,
 ) -> impl Responder {
-    let result = ParticularService::get(&*db, options.into_inner()).await;
+    let result = Service::get(&*db, options.into_inner()).await;
+
+    match result {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(err) => {
+            let error_message = format!("Error: {}", err);
+            HttpResponse::BadRequest().body(error_message)
+        }
+    }
+}
+
+#[get("/api/particular/$count")]
+pub async fn get_count(
+    options: web::Query<QueryParams>,
+    db: web::Data<DatabaseType>,
+) -> impl Responder {
+    let result = Service::get_count(&*db, options.into_inner()).await;
 
     match result {
         Ok(data) => HttpResponse::Ok().json(data),

--- a/src/features/particular/models.rs
+++ b/src/features/particular/models.rs
@@ -1,18 +1,18 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::any::TypeId;
-use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::user::models::UserModel};
+use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::user::models::Model as UserModel};
 
 #[derive(Serialize, Deserialize)]
-pub struct ParticularModel {
+pub struct Model {
     pub id_particular: i32,
     pub description_particular : String,
     pub id_user: Option<i32>
 }
 
-impl Default for ParticularModel {
+impl Default for Model {
     fn default() -> Self {
-        ParticularModel {
+        Model {
             id_particular: 0,
             description_particular: "".to_string(),
             id_user: None
@@ -20,7 +20,7 @@ impl Default for ParticularModel {
     }
 }
 
-impl EntityMetadata for ParticularModel {
+impl EntityMetadata for Model {
     fn metadata() -> &'static EntityDescription {
         lazy_static::lazy_static! {
             static ref METADATA: EntityDescription = {
@@ -54,11 +54,9 @@ impl EntityMetadata for ParticularModel {
                     "User".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: UserModel::metadata().clone(),
-                        related_entity: "User".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_user".to_string()],
                         related_keys: vec!["id_user".to_string()],
-                        navigation_property: "User".to_string(),
                     },
                 );
 

--- a/src/features/particular/repositories.rs
+++ b/src/features/particular/repositories.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-use crate::features::particular::models::ParticularModel;
+use crate::features::particular::models::Model;
 use crate::dto::query_params::QueryParams;
 use crate::database::{Database, DatabaseType};
 
-pub struct ParticularRepository;
+pub struct Repository;
 
-impl ParticularRepository {
+impl Repository {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
@@ -14,10 +14,25 @@ impl ParticularRepository {
         
         match db {
             DatabaseType::Mssql(mssql_db) => {
-                mssql_db.execute::<ParticularModel>(&options).await.map_err(|e| e.to_string())
+                mssql_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
             }
             DatabaseType::Sqlite(sqlite_db) => {
-                sqlite_db.execute::<ParticularModel>(&options).await.map_err(|e| e.to_string())
+                sqlite_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+        }
+    }
+                 
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        match db {
+            DatabaseType::Mssql(mssql_db) => {
+                mssql_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+            DatabaseType::Sqlite(sqlite_db) => {
+                sqlite_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
             }
         }
     }

--- a/src/features/particular/services.rs
+++ b/src/features/particular/services.rs
@@ -1,16 +1,24 @@
 use serde_json::Value;
-use crate::features::particular::repositories::ParticularRepository;
+use crate::features::particular::repositories::Repository;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
-pub struct ParticularService;
+pub struct Service;
 
-impl ParticularService {
+impl Service {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
     ) -> Result<Vec<Value>, String> {
         
-        ParticularRepository::get(db, options).await
+        Repository::get(db, options).await
+    }
+             
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        Repository::get_count(db, options).await
     }
 }

--- a/src/features/particular_user_role_permission/controllers.rs
+++ b/src/features/particular_user_role_permission/controllers.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, web, Responder, HttpResponse};
-use crate::features::particular_user_role_permission::services::ParticularUserRolePermissionService;
+use crate::features::particular_user_role_permission::services::Service;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
@@ -8,7 +8,23 @@ pub async fn get(
     options: web::Query<QueryParams>,
     db: web::Data<DatabaseType>,
 ) -> impl Responder {
-    let result = ParticularUserRolePermissionService::get(&*db, options.into_inner()).await;
+    let result = Service::get(&*db, options.into_inner()).await;
+
+    match result {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(err) => {
+            let error_message = format!("Error: {}", err);
+            HttpResponse::BadRequest().body(error_message)
+        }
+    }
+}
+
+#[get("/api/particular-user-role-permission/$count")]
+pub async fn get_count(
+    options: web::Query<QueryParams>,
+    db: web::Data<DatabaseType>,
+) -> impl Responder {
+    let result = Service::get_count(&*db, options.into_inner()).await;
 
     match result {
         Ok(data) => HttpResponse::Ok().json(data),

--- a/src/features/particular_user_role_permission/models.rs
+++ b/src/features/particular_user_role_permission/models.rs
@@ -1,10 +1,10 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::any::TypeId;
-use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::{particular::models::ParticularModel, permission::models::PermissionModel, role::models::RoleModel, user::models::UserModel}};
+use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::{particular::models::Model as ParticularModel, permission::models::Model as PermissionModel, role::models::Model as RoleModel, user::models::Model as UserModel}};
 
 #[derive(Serialize, Deserialize)]
-pub struct ParticularUserRolePermissionModel {
+pub struct Model {
     pub id_particular_user_role_permission: i32,
     pub id_particular: Option<i32>,
     pub id_user: Option<i32>,
@@ -12,9 +12,9 @@ pub struct ParticularUserRolePermissionModel {
     pub id_permission: Option<i32>
 }
 
-impl Default for ParticularUserRolePermissionModel {
+impl Default for Model {
     fn default() -> Self {
-        ParticularUserRolePermissionModel {
+        Model {
             id_particular_user_role_permission: 0,
             id_particular: None,
             id_user: None,
@@ -24,7 +24,7 @@ impl Default for ParticularUserRolePermissionModel {
     }
 }
 
-impl EntityMetadata for ParticularUserRolePermissionModel {
+impl EntityMetadata for Model {
     fn metadata() -> &'static EntityDescription {
         lazy_static::lazy_static! {
             static ref METADATA: EntityDescription = {
@@ -74,11 +74,9 @@ impl EntityMetadata for ParticularUserRolePermissionModel {
                     "Particular".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: ParticularModel::metadata().clone(),
-                        related_entity: "Particular".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_particular".to_string()],
                         related_keys: vec!["id_particular".to_string()],
-                        navigation_property: "Particular".to_string(),
                     },
                 );
 
@@ -86,11 +84,9 @@ impl EntityMetadata for ParticularUserRolePermissionModel {
                     "User".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: UserModel::metadata().clone(),
-                        related_entity: "User".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_user".to_string()],
                         related_keys: vec!["id_user".to_string()],
-                        navigation_property: "User".to_string(),
                     },
                 );
 
@@ -98,11 +94,9 @@ impl EntityMetadata for ParticularUserRolePermissionModel {
                     "Role".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: RoleModel::metadata().clone(),
-                        related_entity: "Role".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_role".to_string()],
                         related_keys: vec!["id_role".to_string()],
-                        navigation_property: "Role".to_string(),
                     },
                 );
 
@@ -110,11 +104,9 @@ impl EntityMetadata for ParticularUserRolePermissionModel {
                     "Permission".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: PermissionModel::metadata().clone(),
-                        related_entity: "Permission".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_permission".to_string()],
                         related_keys: vec!["id_permission".to_string()],
-                        navigation_property: "Permission".to_string(),
                     },
                 );
 

--- a/src/features/particular_user_role_permission/repositories.rs
+++ b/src/features/particular_user_role_permission/repositories.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-use crate::features::particular_user_role_permission::models::ParticularUserRolePermissionModel;
+use crate::features::particular_user_role_permission::models::Model;
 use crate::dto::query_params::QueryParams;
 use crate::database::{Database, DatabaseType};
 
-pub struct ParticularUserRolePermissionRepository;
+pub struct Repository;
 
-impl ParticularUserRolePermissionRepository {
+impl Repository {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
@@ -14,10 +14,25 @@ impl ParticularUserRolePermissionRepository {
         
         match db {
             DatabaseType::Mssql(mssql_db) => {
-                mssql_db.execute::<ParticularUserRolePermissionModel>(&options).await.map_err(|e| e.to_string())
+                mssql_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
             }
             DatabaseType::Sqlite(sqlite_db) => {
-                sqlite_db.execute::<ParticularUserRolePermissionModel>(&options).await.map_err(|e| e.to_string())
+                sqlite_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+        }
+    }
+                     
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        match db {
+            DatabaseType::Mssql(mssql_db) => {
+                mssql_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+            DatabaseType::Sqlite(sqlite_db) => {
+                sqlite_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
             }
         }
     }

--- a/src/features/particular_user_role_permission/services.rs
+++ b/src/features/particular_user_role_permission/services.rs
@@ -1,16 +1,24 @@
 use serde_json::Value;
-use crate::features::particular_user_role_permission::repositories::ParticularUserRolePermissionRepository;
+use crate::features::particular_user_role_permission::repositories::Repository;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
-pub struct ParticularUserRolePermissionService;
+pub struct Service;
 
-impl ParticularUserRolePermissionService {
+impl Service {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
     ) -> Result<Vec<Value>, String> {
         
-        ParticularUserRolePermissionRepository::get(db, options).await
+        Repository::get(db, options).await
+    }
+                
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        Repository::get_count(db, options).await
     }
 }

--- a/src/features/permission/controllers.rs
+++ b/src/features/permission/controllers.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, web, Responder, HttpResponse};
-use crate::features::permission::services::PermissionService;
+use crate::features::permission::services::Service;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
@@ -8,7 +8,23 @@ pub async fn get(
     options: web::Query<QueryParams>,
     db: web::Data<DatabaseType>,
 ) -> impl Responder {
-    let result = PermissionService::get(&*db, options.into_inner()).await;
+    let result = Service::get(&*db, options.into_inner()).await;
+
+    match result {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(err) => {
+            let error_message = format!("Error: {}", err);
+            HttpResponse::BadRequest().body(error_message)
+        }
+    }
+}
+
+#[get("/api/permission/$count")]
+pub async fn get_count(
+    options: web::Query<QueryParams>,
+    db: web::Data<DatabaseType>,
+) -> impl Responder {
+    let result = Service::get_count(&*db, options.into_inner()).await;
 
     match result {
         Ok(data) => HttpResponse::Ok().json(data),

--- a/src/features/permission/models.rs
+++ b/src/features/permission/models.rs
@@ -4,16 +4,16 @@ use std::any::TypeId;
 use crate::dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata};
 
 #[derive(Serialize, Deserialize)]
-pub struct PermissionModel {
+pub struct Model {
     pub id_permission: i32,
     pub name_permission: String,
     pub description_permission: String
 
 }
 
-impl Default for PermissionModel {
+impl Default for Model {
     fn default() -> Self {
-        PermissionModel {
+        Model {
             id_permission: 0,
             name_permission: "".to_string(),
             description_permission: "".to_string()
@@ -21,7 +21,7 @@ impl Default for PermissionModel {
     }
 }
 
-impl EntityMetadata for PermissionModel {
+impl EntityMetadata for Model {
     fn metadata() -> &'static EntityDescription {
         lazy_static::lazy_static! {
             static ref METADATA: EntityDescription = {

--- a/src/features/permission/repositories.rs
+++ b/src/features/permission/repositories.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-use crate::features::permission::models::PermissionModel;
+use crate::features::permission::models::Model;
 use crate::dto::query_params::QueryParams;
 use crate::database::{Database, DatabaseType};
 
-pub struct PermissionRepository;
+pub struct Repository;
 
-impl PermissionRepository {
+impl Repository {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
@@ -14,10 +14,25 @@ impl PermissionRepository {
         
         match db {
             DatabaseType::Mssql(mssql_db) => {
-                mssql_db.execute::<PermissionModel>(&options).await.map_err(|e| e.to_string())
+                mssql_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
             }
             DatabaseType::Sqlite(sqlite_db) => {
-                sqlite_db.execute::<PermissionModel>(&options).await.map_err(|e| e.to_string())
+                sqlite_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+        }
+    }
+                         
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        match db {
+            DatabaseType::Mssql(mssql_db) => {
+                mssql_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+            DatabaseType::Sqlite(sqlite_db) => {
+                sqlite_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
             }
         }
     }

--- a/src/features/permission/services.rs
+++ b/src/features/permission/services.rs
@@ -1,16 +1,24 @@
 use serde_json::Value;
-use crate::features::permission::repositories::PermissionRepository;
+use crate::features::permission::repositories::Repository;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
-pub struct PermissionService;
+pub struct Service;
 
-impl PermissionService {
+impl Service {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
     ) -> Result<Vec<Value>, String> {
         
-        PermissionRepository::get(db, options).await
+        Repository::get(db, options).await
+    }
+                    
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        Repository::get_count(db, options).await
     }
 }

--- a/src/features/relation/controllers.rs
+++ b/src/features/relation/controllers.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, web, Responder, HttpResponse};
-use crate::features::relation::services::RelationService;
+use crate::features::relation::services::Service;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
@@ -8,7 +8,23 @@ pub async fn get(
     options: web::Query<QueryParams>,
     db: web::Data<DatabaseType>,
 ) -> impl Responder {
-    let result = RelationService::get(&*db, options.into_inner()).await;
+    let result = Service::get(&*db, options.into_inner()).await;
+
+    match result {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(err) => {
+            let error_message = format!("Error: {}", err);
+            HttpResponse::BadRequest().body(error_message)
+        }
+    }
+}
+
+#[get("/api/relation/$count")]
+pub async fn get_count(
+    options: web::Query<QueryParams>,
+    db: web::Data<DatabaseType>,
+) -> impl Responder {
+    let result = Service::get_count(&*db, options.into_inner()).await;
 
     match result {
         Ok(data) => HttpResponse::Ok().json(data),

--- a/src/features/relation/models.rs
+++ b/src/features/relation/models.rs
@@ -4,22 +4,22 @@ use std::any::TypeId;
 use crate::dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata};
 
 #[derive(Serialize, Deserialize)]
-pub struct RelationModel {
+pub struct Model {
     pub id_relation: i32,
     pub type_relation: String
 
 }
 
-impl Default for RelationModel {
+impl Default for Model {
     fn default() -> Self {
-        RelationModel {
+        Model {
             id_relation: 0,
             type_relation: "".to_string()
         }
     }
 }
 
-impl EntityMetadata for RelationModel {
+impl EntityMetadata for Model {
     fn metadata() -> &'static EntityDescription {
         lazy_static::lazy_static! {
             static ref METADATA: EntityDescription = {

--- a/src/features/relation/repositories.rs
+++ b/src/features/relation/repositories.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-use crate::features::relation::models::RelationModel;
+use crate::features::relation::models::Model;
 use crate::dto::query_params::QueryParams;
 use crate::database::{Database, DatabaseType};
 
-pub struct RelationRepository;
+pub struct Repository;
 
-impl RelationRepository {
+impl Repository {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
@@ -14,10 +14,25 @@ impl RelationRepository {
         
         match db {
             DatabaseType::Mssql(mssql_db) => {
-                mssql_db.execute::<RelationModel>(&options).await.map_err(|e| e.to_string())
+                mssql_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
             }
             DatabaseType::Sqlite(sqlite_db) => {
-                sqlite_db.execute::<RelationModel>(&options).await.map_err(|e| e.to_string())
+                sqlite_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+        }
+    }
+                         
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        match db {
+            DatabaseType::Mssql(mssql_db) => {
+                mssql_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+            DatabaseType::Sqlite(sqlite_db) => {
+                sqlite_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
             }
         }
     }

--- a/src/features/relation/services.rs
+++ b/src/features/relation/services.rs
@@ -1,16 +1,24 @@
 use serde_json::Value;
-use crate::features::relation::repositories::RelationRepository;
+use crate::features::relation::repositories::Repository;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
-pub struct RelationService;
+pub struct Service;
 
-impl RelationService {
+impl Service {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
     ) -> Result<Vec<Value>, String> {
         
-        RelationRepository::get(db, options).await
+        Repository::get(db, options).await
+    }
+                        
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        Repository::get_count(db, options).await
     }
 }

--- a/src/features/role/controllers.rs
+++ b/src/features/role/controllers.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, web, Responder, HttpResponse};
-use crate::features::role::services::RoleService;
+use crate::features::role::services::Service;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
@@ -8,7 +8,23 @@ pub async fn get(
     options: web::Query<QueryParams>,
     db: web::Data<DatabaseType>,
 ) -> impl Responder {
-    let result = RoleService::get(&*db, options.into_inner()).await;
+    let result = Service::get(&*db, options.into_inner()).await;
+
+    match result {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(err) => {
+            let error_message = format!("Error: {}", err);
+            HttpResponse::BadRequest().body(error_message)
+        }
+    }
+}
+
+#[get("/api/role/$count")]
+pub async fn get_count(
+    options: web::Query<QueryParams>,
+    db: web::Data<DatabaseType>,
+) -> impl Responder {
+    let result = Service::get_count(&*db, options.into_inner()).await;
 
     match result {
         Ok(data) => HttpResponse::Ok().json(data),

--- a/src/features/role/models.rs
+++ b/src/features/role/models.rs
@@ -4,16 +4,16 @@ use std::any::TypeId;
 use crate::dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata};
 
 #[derive(Serialize, Deserialize)]
-pub struct RoleModel {
+pub struct Model {
     pub id_role: i32,
     pub name_role: String,
     pub description_role: String
 
 }
 
-impl Default for RoleModel {
+impl Default for Model {
     fn default() -> Self {
-        RoleModel {
+        Model {
             id_role: 0,
             name_role: "".to_string(),
             description_role: "".to_string()
@@ -21,7 +21,7 @@ impl Default for RoleModel {
     }
 }
 
-impl EntityMetadata for RoleModel {
+impl EntityMetadata for Model {
     fn metadata() -> &'static EntityDescription {
         lazy_static::lazy_static! {
             static ref METADATA: EntityDescription = {

--- a/src/features/role/repositories.rs
+++ b/src/features/role/repositories.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-use crate::features::role::models::RoleModel;
+use crate::features::role::models::Model;
 use crate::dto::query_params::QueryParams;
 use crate::database::{Database, DatabaseType};
 
-pub struct RoleRepository;
+pub struct Repository;
 
-impl RoleRepository {
+impl Repository {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
@@ -14,10 +14,25 @@ impl RoleRepository {
         
         match db {
             DatabaseType::Mssql(mssql_db) => {
-                mssql_db.execute::<RoleModel>(&options).await.map_err(|e| e.to_string())
+                mssql_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
             }
             DatabaseType::Sqlite(sqlite_db) => {
-                sqlite_db.execute::<RoleModel>(&options).await.map_err(|e| e.to_string())
+                sqlite_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+        }
+    }
+                             
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        match db {
+            DatabaseType::Mssql(mssql_db) => {
+                mssql_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+            DatabaseType::Sqlite(sqlite_db) => {
+                sqlite_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
             }
         }
     }

--- a/src/features/role/services.rs
+++ b/src/features/role/services.rs
@@ -1,16 +1,24 @@
 use serde_json::Value;
-use crate::features::role::repositories::RoleRepository;
+use crate::features::role::repositories::Repository;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
-pub struct RoleService;
+pub struct Service;
 
-impl RoleService {
+impl Service {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
     ) -> Result<Vec<Value>, String> {
         
-        RoleRepository::get(db, options).await
+        Repository::get(db, options).await
+    }
+                            
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        Repository::get_count(db, options).await
     }
 }

--- a/src/features/topic/controllers.rs
+++ b/src/features/topic/controllers.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, web, Responder, HttpResponse};
-use crate::features::topic::services::TopicService;
+use crate::features::topic::services::Service;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
@@ -8,7 +8,23 @@ pub async fn get(
     options: web::Query<QueryParams>,
     db: web::Data<DatabaseType>,
 ) -> impl Responder {
-    let result = TopicService::get(&*db, options.into_inner()).await;
+    let result = Service::get(&*db, options.into_inner()).await;
+
+    match result {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(err) => {
+            let error_message = format!("Error: {}", err);
+            HttpResponse::BadRequest().body(error_message)
+        }
+    }
+}
+
+#[get("/api/topic/$count")]
+pub async fn get_count(
+    options: web::Query<QueryParams>,
+    db: web::Data<DatabaseType>,
+) -> impl Responder {
+    let result = Service::get_count(&*db, options.into_inner()).await;
 
     match result {
         Ok(data) => HttpResponse::Ok().json(data),

--- a/src/features/topic/models.rs
+++ b/src/features/topic/models.rs
@@ -1,19 +1,19 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::any::TypeId;
-use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::{context::models::ContextModel, user::models::UserModel}};
+use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::{context::models::Model as ContextModel, user::models::Model as UserModel}};
 
 #[derive(Serialize, Deserialize)]
-pub struct TopicModel {
+pub struct Model {
     pub id_topic: i32,
     pub name_topic: String,
     pub id_context: Option<i32>,
     pub id_user: Option<i32>,
 }
 
-impl Default for TopicModel {
+impl Default for Model {
     fn default() -> Self {
-        TopicModel {
+        Model {
             id_topic: 0,
             name_topic: "".to_string(),
             id_context: None,
@@ -22,7 +22,7 @@ impl Default for TopicModel {
     }
 }
 
-impl EntityMetadata for TopicModel {
+impl EntityMetadata for Model {
     fn metadata() -> &'static EntityDescription {
         lazy_static::lazy_static! {
             static ref METADATA: EntityDescription = {
@@ -64,11 +64,9 @@ impl EntityMetadata for TopicModel {
                     "Context".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: ContextModel::metadata().clone(),
-                        related_entity: "Context".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_context".to_string()],
                         related_keys: vec!["id_context".to_string()],
-                        navigation_property: "Context".to_string(),
                     },
                 );
 
@@ -76,11 +74,9 @@ impl EntityMetadata for TopicModel {
                     "User".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: UserModel::metadata().clone(),
-                        related_entity: "User".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_user".to_string()],
                         related_keys: vec!["id_user".to_string()],
-                        navigation_property: "User".to_string(),
                     },
                 );
 

--- a/src/features/topic/repositories.rs
+++ b/src/features/topic/repositories.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-use crate::features::topic::models::TopicModel;
+use crate::features::topic::models::Model;
 use crate::dto::query_params::QueryParams;
 use crate::database::{Database, DatabaseType};
 
-pub struct TopicRepository;
+pub struct Repository;
 
-impl TopicRepository {
+impl Repository {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
@@ -14,10 +14,25 @@ impl TopicRepository {
         
         match db {
             DatabaseType::Mssql(mssql_db) => {
-                mssql_db.execute::<TopicModel>(&options).await.map_err(|e| e.to_string())
+                mssql_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
             }
             DatabaseType::Sqlite(sqlite_db) => {
-                sqlite_db.execute::<TopicModel>(&options).await.map_err(|e| e.to_string())
+                sqlite_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+        }
+    }
+                                 
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        match db {
+            DatabaseType::Mssql(mssql_db) => {
+                mssql_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+            DatabaseType::Sqlite(sqlite_db) => {
+                sqlite_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
             }
         }
     }

--- a/src/features/topic/services.rs
+++ b/src/features/topic/services.rs
@@ -1,16 +1,24 @@
 use serde_json::Value;
-use crate::features::topic::repositories::TopicRepository;
+use crate::features::topic::repositories::Repository;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
-pub struct TopicService;
+pub struct Service;
 
-impl TopicService {
+impl Service {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
     ) -> Result<Vec<Value>, String> {
         
-        TopicRepository::get(db, options).await
+        Repository::get(db, options).await
+    }
+                                
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        Repository::get_count(db, options).await
     }
 }

--- a/src/features/user/controllers.rs
+++ b/src/features/user/controllers.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, web, Responder, HttpResponse};
-use crate::features::user::services::UserService;
+use crate::features::user::services::Service;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
@@ -8,7 +8,23 @@ pub async fn get(
     options: web::Query<QueryParams>,
     db: web::Data<DatabaseType>,
 ) -> impl Responder {
-    let result = UserService::get(&*db, options.into_inner()).await;
+    let result = Service::get(&*db, options.into_inner()).await;
+
+    match result {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(err) => {
+            let error_message = format!("Error: {}", err);
+            HttpResponse::BadRequest().body(error_message)
+        }
+    }
+}
+
+#[get("/api/user/$count")]
+pub async fn get_count(
+    options: web::Query<QueryParams>,
+    db: web::Data<DatabaseType>,
+) -> impl Responder {
+    let result = Service::get_count(&*db, options.into_inner()).await;
 
     match result {
         Ok(data) => HttpResponse::Ok().json(data),

--- a/src/features/user/models.rs
+++ b/src/features/user/models.rs
@@ -5,15 +5,15 @@ use std::any::TypeId;
 use crate::dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata};
 
 #[derive(Serialize, Deserialize)]
-pub struct UserModel {
+pub struct Model {
     pub id_user: i32,
     pub name_user: String,
     pub date_user: NaiveDateTime
 }
 
-impl Default for UserModel {
+impl Default for Model {
     fn default() -> Self {
-        UserModel {
+        Model {
             id_user: 0,
             name_user: "".to_string(),
             date_user: Utc.with_ymd_and_hms(0,0,0,0,0,0).unwrap().naive_local(),
@@ -21,7 +21,7 @@ impl Default for UserModel {
     }
 }
 
-impl EntityMetadata for UserModel {
+impl EntityMetadata for Model {
     fn metadata() -> &'static EntityDescription {
         lazy_static::lazy_static! {
             static ref METADATA: EntityDescription = {

--- a/src/features/user/repositories.rs
+++ b/src/features/user/repositories.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-use crate::features::user::models::UserModel;
+use crate::features::user::models::Model;
 use crate::dto::query_params::QueryParams;
 use crate::database::{Database, DatabaseType};
 
-pub struct UserRepository;
+pub struct Repository;
 
-impl UserRepository {
+impl Repository {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
@@ -14,10 +14,25 @@ impl UserRepository {
         
         match db {
             DatabaseType::Mssql(mssql_db) => {
-                mssql_db.execute::<UserModel>(&options).await.map_err(|e| e.to_string())
+                mssql_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
             }
             DatabaseType::Sqlite(sqlite_db) => {
-                sqlite_db.execute::<UserModel>(&options).await.map_err(|e| e.to_string())
+                sqlite_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+        }
+    }
+                                     
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        match db {
+            DatabaseType::Mssql(mssql_db) => {
+                mssql_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+            DatabaseType::Sqlite(sqlite_db) => {
+                sqlite_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
             }
         }
     }

--- a/src/features/user/services.rs
+++ b/src/features/user/services.rs
@@ -1,16 +1,24 @@
 use serde_json::Value;
-use crate::features::user::repositories::UserRepository;
+use crate::features::user::repositories::Repository;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
-pub struct UserService;
+pub struct Service;
 
-impl UserService {
+impl Service {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
     ) -> Result<Vec<Value>, String> {
         
-        UserRepository::get(db, options).await
+        Repository::get(db, options).await
+    }
+                                    
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        Repository::get_count(db, options).await
     }
 }

--- a/src/features/user_authentication_type/controllers.rs
+++ b/src/features/user_authentication_type/controllers.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, web, Responder, HttpResponse};
-use crate::features::user_authentication_type::services::UserAuthenticationTypeService;
+use crate::features::user_authentication_type::services::Service;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
@@ -8,7 +8,23 @@ pub async fn get(
     options: web::Query<QueryParams>,
     db: web::Data<DatabaseType>,
 ) -> impl Responder {
-    let result = UserAuthenticationTypeService::get(&*db, options.into_inner()).await;
+    let result = Service::get(&*db, options.into_inner()).await;
+
+    match result {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(err) => {
+            let error_message = format!("Error: {}", err);
+            HttpResponse::BadRequest().body(error_message)
+        }
+    }
+}
+
+#[get("/api/user-authentication-type/$count")]
+pub async fn get_count(
+    options: web::Query<QueryParams>,
+    db: web::Data<DatabaseType>,
+) -> impl Responder {
+    let result = Service::get_count(&*db, options.into_inner()).await;
 
     match result {
         Ok(data) => HttpResponse::Ok().json(data),

--- a/src/features/user_authentication_type/models.rs
+++ b/src/features/user_authentication_type/models.rs
@@ -2,10 +2,10 @@ use chrono::{NaiveDateTime, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::any::TypeId;
-use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::{authentication_type::models::AuthenticationTypeModel, user::models::UserModel}};
+use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::{authentication_type::models::Model as AuthenticationTypeModel, user::models::Model as UserModel}};
 
 #[derive(Serialize, Deserialize)]
-pub struct UserAuthenticationTypeModel {
+pub struct Model {
     pub id_user_authentication_type: i32,
     pub date_user_authentication_type: NaiveDateTime,
     pub active_user_authentication_type: bool,
@@ -13,9 +13,9 @@ pub struct UserAuthenticationTypeModel {
     pub id_user: Option<i32>,
 }
 
-impl Default for UserAuthenticationTypeModel {
+impl Default for Model {
     fn default() -> Self {
-        UserAuthenticationTypeModel {
+        Model {
             id_user_authentication_type: 0,
             date_user_authentication_type: Utc.with_ymd_and_hms(0,0,0,0,0,0).unwrap().naive_local(),
             active_user_authentication_type: false,
@@ -25,7 +25,7 @@ impl Default for UserAuthenticationTypeModel {
     }
 }
 
-impl EntityMetadata for UserAuthenticationTypeModel {
+impl EntityMetadata for Model {
     fn metadata() -> &'static EntityDescription {
         lazy_static::lazy_static! {
             static ref METADATA: EntityDescription = {
@@ -75,11 +75,9 @@ impl EntityMetadata for UserAuthenticationTypeModel {
                     "AuthenticationType".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: AuthenticationTypeModel::metadata().clone(),
-                        related_entity: "AuthenticationType".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_authentication_type".to_string()],
                         related_keys: vec!["id_authentication_type".to_string()],
-                        navigation_property: "AuthenticationType".to_string(),
                     },
                 );
 
@@ -87,11 +85,9 @@ impl EntityMetadata for UserAuthenticationTypeModel {
                     "User".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: UserModel::metadata().clone(),
-                        related_entity: "User".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_user".to_string()],
                         related_keys: vec!["id_user".to_string()],
-                        navigation_property: "User".to_string(),
                     },
                 );
 

--- a/src/features/user_authentication_type/repositories.rs
+++ b/src/features/user_authentication_type/repositories.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-use crate::features::user_authentication_type::models::UserAuthenticationTypeModel;
+use crate::features::user_authentication_type::models::Model;
 use crate::dto::query_params::QueryParams;
 use crate::database::{Database, DatabaseType};
 
-pub struct UserAuthenticationTypeRepository;
+pub struct Repository;
 
-impl UserAuthenticationTypeRepository {
+impl Repository {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
@@ -14,10 +14,25 @@ impl UserAuthenticationTypeRepository {
         
         match db {
             DatabaseType::Mssql(mssql_db) => {
-                mssql_db.execute::<UserAuthenticationTypeModel>(&options).await.map_err(|e| e.to_string())
+                mssql_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
             }
             DatabaseType::Sqlite(sqlite_db) => {
-                sqlite_db.execute::<UserAuthenticationTypeModel>(&options).await.map_err(|e| e.to_string())
+                sqlite_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+        }
+    }
+                                         
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        match db {
+            DatabaseType::Mssql(mssql_db) => {
+                mssql_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+            DatabaseType::Sqlite(sqlite_db) => {
+                sqlite_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
             }
         }
     }

--- a/src/features/user_authentication_type/services.rs
+++ b/src/features/user_authentication_type/services.rs
@@ -1,16 +1,24 @@
 use serde_json::Value;
-use crate::features::user_authentication_type::repositories::UserAuthenticationTypeRepository;
+use crate::features::user_authentication_type::repositories::Repository;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
-pub struct UserAuthenticationTypeService;
+pub struct Service;
 
-impl UserAuthenticationTypeService {
+impl Service {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
     ) -> Result<Vec<Value>, String> {
         
-        UserAuthenticationTypeRepository::get(db, options).await
+        Repository::get(db, options).await
+    }
+                                        
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        Repository::get_count(db, options).await
     }
 }

--- a/src/features/user_system/controllers.rs
+++ b/src/features/user_system/controllers.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, web, Responder, HttpResponse};
-use crate::features::user_system::services::UserSystemService;
+use crate::features::user_system::services::Service;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
@@ -8,7 +8,23 @@ pub async fn get(
     options: web::Query<QueryParams>,
     db: web::Data<DatabaseType>,
 ) -> impl Responder {
-    let result = UserSystemService::get(&*db, options.into_inner()).await;
+    let result = Service::get(&*db, options.into_inner()).await;
+
+    match result {
+        Ok(data) => HttpResponse::Ok().json(data),
+        Err(err) => {
+            let error_message = format!("Error: {}", err);
+            HttpResponse::BadRequest().body(error_message)
+        }
+    }
+}
+
+#[get("/api/user-system/$count")]
+pub async fn get_count(
+    options: web::Query<QueryParams>,
+    db: web::Data<DatabaseType>,
+) -> impl Responder {
+    let result = Service::get_count(&*db, options.into_inner()).await;
 
     match result {
         Ok(data) => HttpResponse::Ok().json(data),

--- a/src/features/user_system/models.rs
+++ b/src/features/user_system/models.rs
@@ -1,18 +1,18 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::any::TypeId;
-use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::user::models::UserModel};
+use crate::{dto::metadata::{ColumnMetadata, EntityDescription, EntityMetadata, RelationshipMetadata, RelationshipType}, features::user::models::Model as UserModel};
 
 #[derive(Serialize, Deserialize)]
-pub struct UserSystemModel {
+pub struct Model {
     pub id_user_system: i32,
     pub password_user: String,
     pub id_user: Option<i32>
 }
 
-impl Default for UserSystemModel {
+impl Default for Model {
     fn default() -> Self {
-        UserSystemModel {
+        Model {
             id_user_system: 0,
             password_user: "".to_string(),
             id_user: None
@@ -20,7 +20,7 @@ impl Default for UserSystemModel {
     }
 }
 
-impl EntityMetadata for UserSystemModel {
+impl EntityMetadata for Model {
     fn metadata() -> &'static EntityDescription {
         lazy_static::lazy_static! {
             static ref METADATA: EntityDescription = {
@@ -54,11 +54,9 @@ impl EntityMetadata for UserSystemModel {
                     "User".to_string(),
                     RelationshipMetadata {
                         related_entity_metadata: UserModel::metadata().clone(),
-                        related_entity: "User".to_string(),
                         relationship_type: RelationshipType::ManyToOne,
                         foreign_keys: vec!["id_user".to_string()],
                         related_keys: vec!["id_user".to_string()],
-                        navigation_property: "User".to_string(),
                     },
                 );
 

--- a/src/features/user_system/repositories.rs
+++ b/src/features/user_system/repositories.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 
-use crate::features::user_system::models::UserSystemModel;
+use crate::features::user_system::models::Model;
 use crate::dto::query_params::QueryParams;
 use crate::database::{Database, DatabaseType};
 
-pub struct UserSystemRepository;
+pub struct Repository;
 
-impl UserSystemRepository {
+impl Repository {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
@@ -14,10 +14,25 @@ impl UserSystemRepository {
         
         match db {
             DatabaseType::Mssql(mssql_db) => {
-                mssql_db.execute::<UserSystemModel>(&options).await.map_err(|e| e.to_string())
+                mssql_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
             }
             DatabaseType::Sqlite(sqlite_db) => {
-                sqlite_db.execute::<UserSystemModel>(&options).await.map_err(|e| e.to_string())
+                sqlite_db.execute::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+        }
+    }
+                                             
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        match db {
+            DatabaseType::Mssql(mssql_db) => {
+                mssql_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
+            }
+            DatabaseType::Sqlite(sqlite_db) => {
+                sqlite_db.execute_count::<Model>(&options).await.map_err(|e| e.to_string())
             }
         }
     }

--- a/src/features/user_system/services.rs
+++ b/src/features/user_system/services.rs
@@ -1,16 +1,24 @@
 use serde_json::Value;
-use crate::features::user_system::repositories::UserSystemRepository;
+use crate::features::user_system::repositories::Repository;
 use crate::dto::query_params::QueryParams;
 use crate::database::DatabaseType;
 
-pub struct UserSystemService;
+pub struct Service;
 
-impl UserSystemService {
+impl Service {
     pub async fn get(
         db: &DatabaseType,
         options: QueryParams,
     ) -> Result<Vec<Value>, String> {
         
-        UserSystemRepository::get(db, options).await
+        Repository::get(db, options).await
+    }
+                                            
+    pub async fn get_count(
+        db: &DatabaseType,
+        options: QueryParams,
+    ) -> Result<Value, String> {
+        
+        Repository::get_count(db, options).await
     }
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -52,6 +52,14 @@ pub mod query {
                     }
                 }
 
+                pub mod count {
+                    pub mod count;
+                  
+                    pub mod context {
+                        pub mod context;
+                    }
+                }
+
                 pub mod select {
                     pub mod select;
 
@@ -118,6 +126,9 @@ pub mod query {
                     pub mod orderby {
                         pub mod token;
                     }
+                    pub mod compute {
+                        pub mod token;
+                    }
                 }
             }
 
@@ -134,8 +145,33 @@ pub mod query {
                     }
                 }
 
+                pub mod compute {
+                    pub mod compute;
+
+                    pub mod token {
+                        pub mod tokenization;
+                    }
+
+                    pub mod context {
+                        pub mod context;
+                    }
+                }
+
+                pub mod count {
+                    pub mod count;
+                  
+                    pub mod context {
+                        pub mod context;
+                    }
+                }
+
                 pub mod select {
                     pub mod select;
+
+                    // [Specific module the handle $compute operations]
+                    pub mod compute {
+                        pub mod compute;
+                    }
 
                     pub mod token {
                         pub mod tokenization;
@@ -144,6 +180,11 @@ pub mod query {
     
                 pub mod filter {
                     pub mod filter;
+
+                    // [Specific module the handle $compute operations]
+                    pub mod compute {
+                        pub mod compute;
+                    }
     
                     pub mod token {
                         pub mod tokenization;
@@ -152,6 +193,11 @@ pub mod query {
    
                 pub mod orderby {
                     pub mod orderby;
+
+                    // [Specific module the handle $compute operations]
+                    pub mod compute {
+                        pub mod compute;
+                    }
 
                     pub mod token {
                         pub mod tokenization;
@@ -165,7 +211,7 @@ pub mod query {
                 pub mod skip {
                     pub mod skip;
                 }
-            } 
+            }  
         }
     } 
 } 

--- a/src/services/query/database/mssql/common/tokens/compute/token.rs
+++ b/src/services/query/database/mssql/common/tokens/compute/token.rs
@@ -1,0 +1,77 @@
+use std::any::TypeId;
+
+use crate::database::mssql::common::context::contextualizer::{ContextualizerColumnMetadata, ContextualizerEntityDescription};
+
+#[derive(Debug, Clone)]
+pub enum Token {
+    Operation {
+        operation_type: Operation
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Operation {
+    Arithmetic {
+        operation: ArithmeticOperation
+    },
+    Alias {
+        operation: AliasOperation
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Operand {
+    pub metadata: ContextualizerEntityDescription,
+    pub column_metadata: ContextualizerColumnMetadata,
+}
+
+#[derive(Debug, Clone)]
+pub enum ArithmeticOperation {
+    Addition {
+        left_operand: Operand,
+        right_operand: Operand,
+        alias_name: String,
+        alias_type: TypeId
+    },
+    Subtration {
+        left_operand: Operand,
+        right_operand: Operand,
+        alias_name: String,
+        alias_type: TypeId
+    },
+    Multiplication {
+        left_operand: Operand,
+        right_operand: Operand,
+        alias_name: String,
+        alias_type: TypeId
+    },
+    Division {
+        left_operand: Operand,
+        right_operand: Operand,
+        alias_name: String,
+        alias_type: TypeId
+    },
+    Module {
+        left_operand: Operand,
+        right_operand: Operand,
+        alias_name: String,
+        alias_type: TypeId
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AliasOperation {
+    pub metadata: ContextualizerEntityDescription,
+    pub column_metadata: ContextualizerColumnMetadata,
+    pub alias_name: String,
+    pub alias_type: TypeId
+}
+
+
+impl Token {
+    pub fn new_operation(operation_type: Operation) -> Self {
+        Token::Operation {
+            operation_type
+        }
+    }
+}

--- a/src/services/query/database/mssql/operations/compute/compute.rs
+++ b/src/services/query/database/mssql/operations/compute/compute.rs
@@ -1,0 +1,34 @@
+use crate::database::mssql::common::context::contextualizer::ContextualizerMetadata;
+use crate::services::query::database::mssql::common::tokens::compute::token::Token;
+
+use super::{token::tokenization::Tokenization, context::context::Context};
+
+pub struct Compute;
+
+impl Compute {
+    pub fn process(
+        text: Option<&str>,
+        contextualizer: &mut ContextualizerMetadata,
+    ) -> Result<(), String> {
+
+        let error = |message: String| -> String {
+            format!("Invalid $compute: {}", message)
+        };
+
+        let mut tokens: Vec<Token> = Vec::new();
+
+        if let Some(text) = text {
+            tokens = match Tokenization::tokenize(text, contextualizer) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
+        }
+
+        match Context::resolve_context(&tokens, contextualizer){
+            Err(err) => return Err(error(err)),
+            Ok(value) => value
+        };
+
+        Ok(())
+    }   
+}

--- a/src/services/query/database/mssql/operations/compute/context/context.rs
+++ b/src/services/query/database/mssql/operations/compute/context/context.rs
@@ -1,0 +1,168 @@
+use crate::database::mssql::common::context::contextualizer::{ComputeAliasOperation, ComputeArithmeticOperation, ComputeOperand, ComputeOperation, ComputeSpecificationMetadata, ContextualizerColumnMetadata, ContextualizerMetadata};
+use crate::services::query::database::mssql::common::tokens::compute::token::{ArithmeticOperation, Operation, Token};
+
+pub struct Context;
+
+impl Context {
+    pub fn resolve_context(
+        tokens: &[Token],
+        contextualizer: &mut ContextualizerMetadata,
+    ) -> Result<(), String> {  
+
+        let mut metadata = contextualizer.get_context();
+
+        for token in tokens {
+            match token {
+                Token::Operation { operation_type: operation} => {
+                    match operation {
+                        Operation::Alias { operation} => {
+
+                            metadata.columns.insert(operation.alias_name.to_string(), 
+                                ContextualizerColumnMetadata::Dynamic {
+
+                                    column_name: operation.alias_name.to_string(),
+                                    column_type: operation.alias_type,
+
+                                    specification: ComputeSpecificationMetadata {
+                                        operation_type: ComputeOperation::Alias {
+                                            operation: ComputeAliasOperation {
+                                                table_name: operation.metadata.table_name.clone(),
+                                                column_name: operation.column_metadata.column_name().clone()
+                                            }
+                                        }
+                                    }
+                                });
+
+                        },
+                        Operation::Arithmetic { operation } => {
+
+                            match operation {
+                                ArithmeticOperation::Addition { left_operand, right_operand, alias_name, alias_type } => {
+                                    metadata.columns.insert(alias_name.to_string(), 
+                                        ContextualizerColumnMetadata::Dynamic {
+                                        
+                                            column_name: alias_name.to_string(),
+                                            column_type: *alias_type,
+                                        
+                                            specification: ComputeSpecificationMetadata {
+                                                operation_type: ComputeOperation::Arithmetic {
+                                                    operation: ComputeArithmeticOperation::Addition {
+                                                        left_operand: ComputeOperand {
+                                                            table_name: left_operand.metadata.table_name.clone(),
+                                                            column_name: left_operand.column_metadata.column_name().clone()
+                                                        },
+                                                        right_operand: ComputeOperand {
+                                                            table_name: right_operand.metadata.table_name.clone(),
+                                                            column_name: right_operand.column_metadata.column_name().clone()
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        });
+                                },
+                                ArithmeticOperation::Subtration { left_operand, right_operand, alias_name, alias_type } => {
+                                    metadata.columns.insert(alias_name.to_string(), 
+                                        ContextualizerColumnMetadata::Dynamic {
+                                        
+                                            column_name: alias_name.to_string(),
+                                            column_type: *alias_type,
+                                        
+                                            specification: ComputeSpecificationMetadata {
+                                                operation_type: ComputeOperation::Arithmetic {
+                                                    operation: ComputeArithmeticOperation::Subtration {
+                                                        left_operand: ComputeOperand {
+                                                            table_name: left_operand.metadata.table_name.clone(),
+                                                            column_name: left_operand.column_metadata.column_name().clone()
+                                                        },
+                                                        right_operand: ComputeOperand {
+                                                            table_name: right_operand.metadata.table_name.clone(),
+                                                            column_name: right_operand.column_metadata.column_name().clone()
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        });
+                                },
+                                ArithmeticOperation::Multiplication { left_operand, right_operand, alias_name, alias_type } => {
+                                    metadata.columns.insert(alias_name.to_string(), 
+                                        ContextualizerColumnMetadata::Dynamic {
+                                        
+                                            column_name: alias_name.to_string(),
+                                            column_type: *alias_type,
+                                        
+                                            specification: ComputeSpecificationMetadata {
+                                                operation_type: ComputeOperation::Arithmetic {
+                                                    operation: ComputeArithmeticOperation::Multiplication {
+                                                        left_operand: ComputeOperand {
+                                                            table_name: left_operand.metadata.table_name.clone(),
+                                                            column_name: left_operand.column_metadata.column_name().clone()
+                                                        },
+                                                        right_operand: ComputeOperand {
+                                                            table_name: right_operand.metadata.table_name.clone(),
+                                                            column_name: right_operand.column_metadata.column_name().clone()
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        });
+                                },
+                                ArithmeticOperation::Division { left_operand, right_operand, alias_name, alias_type } => {
+                                    metadata.columns.insert(alias_name.to_string(), 
+                                        ContextualizerColumnMetadata::Dynamic {
+                                        
+                                            column_name: alias_name.to_string(),
+                                            column_type: *alias_type,
+                                        
+                                            specification: ComputeSpecificationMetadata {
+                                                operation_type: ComputeOperation::Arithmetic {
+                                                    operation: ComputeArithmeticOperation::Division {
+                                                        left_operand: ComputeOperand {
+                                                            table_name: left_operand.metadata.table_name.clone(),
+                                                            column_name: left_operand.column_metadata.column_name().clone()
+                                                        },
+                                                        right_operand: ComputeOperand {
+                                                            table_name: right_operand.metadata.table_name.clone(),
+                                                            column_name: right_operand.column_metadata.column_name().clone()
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        });
+                                },
+                                ArithmeticOperation::Module { left_operand, right_operand, alias_name, alias_type } => {
+                                    metadata.columns.insert(alias_name.to_string(), 
+                                        ContextualizerColumnMetadata::Dynamic {
+                                        
+                                            column_name: alias_name.to_string(),
+                                            column_type: *alias_type,
+                                        
+                                            specification: ComputeSpecificationMetadata {
+                                                operation_type: ComputeOperation::Arithmetic {
+                                                    operation: ComputeArithmeticOperation::Module {
+                                                        left_operand: ComputeOperand {
+                                                            table_name: left_operand.metadata.table_name.clone(),
+                                                            column_name: left_operand.column_metadata.column_name().clone()
+                                                        },
+                                                        right_operand: ComputeOperand {
+                                                            table_name: right_operand.metadata.table_name.clone(),
+                                                            column_name: right_operand.column_metadata.column_name().clone()
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        });
+                                }
+                            }
+
+                        }
+                    }
+
+                }
+            }
+        }
+
+        contextualizer.update_context(metadata.clone());
+
+        Ok(())
+    }
+}

--- a/src/services/query/database/mssql/operations/compute/token/tokenization.rs
+++ b/src/services/query/database/mssql/operations/compute/token/tokenization.rs
@@ -1,0 +1,414 @@
+use regex::Regex;
+use std::{any::TypeId, cell::RefCell, collections::{HashMap, HashSet}, rc::Rc};
+use chrono::{NaiveDate, NaiveDateTime};
+use lazy_static::lazy_static;
+use dynamic_queries_api::EventfulPeekable;
+
+use crate::{database::mssql::common::context::contextualizer::{ContextualizerColumnMetadata, ContextualizerEntityDescription, ContextualizerMetadata}, services::query::database::mssql::common::tokens::compute::token::{AliasOperation, ArithmeticOperation, Operand}};
+use crate::services::query::database::mssql::common::tokens::compute::token::{Token, Operation};
+
+lazy_static! {
+    static ref OPERATORS: HashSet<&'static str> = {
+        let mut set = HashSet::new();
+        set.insert("as");
+        set
+    }; 
+
+    static ref ARITHMETIC_OPERATORS: HashSet<&'static str> = {
+        let mut set = HashSet::new();
+        set.insert("add");
+        set.insert("sub");
+        set.insert("mul");
+        set.insert("div");
+        set.insert("mod");
+        set
+    }; 
+
+    static ref VALID_ARITHMETIC_OPERATORS: HashMap<TypeId, Vec<&'static str>> = {
+        let mut map = HashMap::new();
+
+        map.insert(TypeId::of::<String>(), vec![]);
+        map.insert(TypeId::of::<Option<String>>(), vec![]);
+        
+        map.insert(TypeId::of::<bool>(), vec![]);
+        map.insert(TypeId::of::<Option<bool>>(), vec![]);
+
+        map.insert(TypeId::of::<i16>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<i32>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<i64>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<i128>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<Option<i16>>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<Option<i32>>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<Option<i64>>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<Option<i128>>(), vec!["add", "sub", "mul", "div", "mod"]);
+
+        map.insert(TypeId::of::<f32>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<f64>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<Option<f32>>(), vec!["add", "sub", "mul", "div", "mod"]);
+        map.insert(TypeId::of::<Option<f64>>(), vec!["add", "sub", "mul", "div", "mod"]);
+
+        map.insert(TypeId::of::<NaiveDate>(), vec![]);
+        map.insert(TypeId::of::<NaiveDateTime>(), vec![]);
+        map.insert(TypeId::of::<Option<NaiveDate>>(), vec![]);
+        map.insert(TypeId::of::<Option<NaiveDateTime>>(), vec![]);
+        
+        map
+    };
+}
+
+pub struct Tokenization;
+
+impl Tokenization {
+    fn split(text: &str) -> Result<Vec<String>, String> {
+        let mut tokens = Vec::new();
+        let mut current_token = String::new();
+        
+        for char in text.chars() {
+            match char {
+                ',' => {
+                    if !current_token.trim().is_empty() {
+                        tokens.push(current_token.trim().to_string());
+                        current_token.clear();
+                    }
+                    tokens.push(char.to_string());
+                },
+                ' ' => {
+                    if !current_token.trim().is_empty() {
+                        tokens.push(current_token.trim().to_string());
+                        current_token.clear();
+                    }
+                },
+                _ => {
+                    current_token.push(char);
+                }
+            }
+        }
+    
+        // [Add the last token if necessary]
+        if !current_token.trim().is_empty() {
+            tokens.push(current_token.trim().to_string());
+        }
+    
+        Ok(tokens)
+    }
+
+    fn resolve_nested_metadata(metadata: &ContextualizerEntityDescription, token: &str) -> Result<(ContextualizerEntityDescription, ContextualizerColumnMetadata), String> {
+        let parts: Vec<&str> = token.split('/').collect();
+
+        if parts.len() < 2 {
+            return Err(format!("Invalid nested token format: {}", token));
+        }
+
+        let mut current_metadata = metadata.clone();
+
+        for (i, part) in parts.iter().enumerate() {
+            if i == parts.len() - 1 {
+                
+                // [Last part should be a field in the related entity]
+                let metadata = current_metadata.clone();
+
+                let column_metadata = metadata
+                    .columns
+                    .get(*part)
+                    .cloned()
+                    .ok_or_else(|| format!("Invalid token in related entity: {}", part))?;
+
+                return Ok((metadata, column_metadata));
+
+            } else {
+                // [Intermediate parts should be relationships]
+                let relationship = current_metadata
+                    .relationships
+                    .get(*part)
+                    .ok_or_else(|| format!("Invalid related entity: {}", part))?;
+
+                // [Expanded]
+                if !relationship.expanded {
+                    return Err(format!("Non expanded relation: {}", part));
+                }
+
+                current_metadata = relationship.related_entity_metadata.clone();
+            }
+        }
+
+        Err(format!("Unexpected error resolving metadata for token: {}", token))
+    }
+
+    fn resolve_non_nested_metadata(metadata: &ContextualizerEntityDescription, token: &str) -> Result<(ContextualizerEntityDescription, ContextualizerColumnMetadata), String> {
+        
+        let metadata = metadata.clone();
+
+        let column_metadata = metadata
+            .columns
+            .get(token)
+            .cloned()
+            .ok_or_else(|| format!("Invalid token: {}", token))?;
+
+            return Ok((metadata, column_metadata));
+    }
+
+    fn get_metadata(metadata: &ContextualizerEntityDescription, token: &str) -> Result<(ContextualizerEntityDescription, ContextualizerColumnMetadata), String> {
+        if token.contains('/') {
+            Self::resolve_nested_metadata(metadata, token)
+        } else {
+            Self::resolve_non_nested_metadata(metadata, token)
+        }
+    }
+    
+    fn get_operation(metadata: &ContextualizerEntityDescription, tokens_iter: &mut EventfulPeekable<std::slice::Iter<'_, String>>, token: &str) -> Result<Operation, String> {
+        
+        // [ArithmeticOperation]
+        // [column_name + arithmetic_operator + column_name + alias + alias_name]
+
+        // [AliasOperation]
+        // [column_name + alias + alias_name]
+
+        // [left-side metadata]
+        let left_operand: &str = token; 
+
+        let (left_operand_metadata, left_operand_column_metadata ) = Self::get_metadata(&metadata, left_operand)?;
+
+        // [first-operator]
+        let first_operator: &str = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {}", token))?; 
+
+        Self::validate_operator(first_operator)?;
+
+        // [AliasOperation]
+        if first_operator == "as" {
+            
+            // [alias]
+            let alias_name: &str = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {}", first_operator))?; 
+
+            Self::validate_alias_name(alias_name)?;
+
+            let alias_operation = 
+                AliasOperation {
+                    metadata: left_operand_metadata.clone(),
+                    column_metadata: left_operand_column_metadata.clone(),
+                    alias_name: alias_name.to_string(),
+                    alias_type: left_operand_column_metadata.column_type(),
+            };
+
+            return Ok(Operation::Alias { operation: alias_operation });
+        }
+
+        // [ArithmeticOperation]
+
+        // [right-side metadata]
+        let right_operand: &str = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {}", first_operator))?; 
+
+        let (right_operand_metadata, right_operand_column_metadata ) = Self::get_metadata(&metadata, right_operand)?;
+
+        Self::validate_arithmetic_operator(first_operator, &left_operand_column_metadata, &right_operand_column_metadata)?;
+
+        // [second-operator]
+        let second_operator: &str = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {}", token))?; 
+
+        if second_operator != "as" {
+            return Err(format!("Operator '{}' is not a valid operator", second_operator));
+        }
+
+        let common_type = left_operand_column_metadata.column_type();
+
+        // [alias]
+        let alias_name: &str = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {}", second_operator))?; 
+
+        Self::validate_alias_name(alias_name)?;
+
+        let arithmetic_operation = match first_operator {
+            "add" => ArithmeticOperation::Addition {
+                left_operand: Operand {
+                    metadata: left_operand_metadata,
+                    column_metadata: left_operand_column_metadata
+                },
+                right_operand: Operand {
+                    metadata: right_operand_metadata,
+                    column_metadata: right_operand_column_metadata
+                },
+                alias_name: alias_name.to_string(),
+                alias_type: common_type
+            },
+            "sub" => ArithmeticOperation::Subtration {
+                left_operand: Operand {
+                    metadata: left_operand_metadata,
+                    column_metadata: left_operand_column_metadata
+                },
+                right_operand: Operand {
+                    metadata: right_operand_metadata,
+                    column_metadata: right_operand_column_metadata
+                },
+                alias_name: alias_name.to_string(),
+                alias_type: common_type
+            },
+            "mul" => ArithmeticOperation::Multiplication {
+                left_operand: Operand {
+                    metadata: left_operand_metadata,
+                    column_metadata: left_operand_column_metadata
+                },
+                right_operand: Operand {
+                    metadata: right_operand_metadata,
+                    column_metadata: right_operand_column_metadata
+                },
+                alias_name: alias_name.to_string(),
+                alias_type: common_type
+            },
+            "div" => ArithmeticOperation::Division {
+                left_operand: Operand {
+                    metadata: left_operand_metadata,
+                    column_metadata: left_operand_column_metadata
+                },
+                right_operand: Operand {
+                    metadata: right_operand_metadata,
+                    column_metadata: right_operand_column_metadata
+                },
+                alias_name: alias_name.to_string(),
+                alias_type: common_type
+            },
+            "mod" => ArithmeticOperation::Module {
+                left_operand: Operand {
+                    metadata: left_operand_metadata,
+                    column_metadata: left_operand_column_metadata
+                },
+                right_operand: Operand {
+                    metadata: right_operand_metadata,
+                    column_metadata: right_operand_column_metadata
+                },
+                alias_name: alias_name.to_string(),
+                alias_type: common_type
+            },
+            _ => return Err(format!("Unsupported arithmetic operator '{}' between  left-operand '{}' and right-operand '{}'", left_operand_column_metadata.column_name(), right_operand_column_metadata.column_name(), first_operator)),
+        };
+
+        return Ok(Operation::Arithmetic { operation:  arithmetic_operation });
+    }
+
+    fn validate_alias_name(alias_name: &str) -> Result<(), String> {
+        
+        let alias_name_regex = Regex::new(r"^[A-Za-z0-9-_]+$").unwrap();
+        
+        if !alias_name_regex.is_match(alias_name) {
+            return Err(format!("Invalid alias name '{}'. [A-Za-z0-9-_]", alias_name));
+        }
+
+        Ok(())
+    }
+
+    fn validate_operator(operator: &str) -> Result<(), String> {
+        if !OPERATORS.contains(operator) && !ARITHMETIC_OPERATORS.contains(operator) {
+            return Err(format!("Operator '{}' is not a valid operator", operator));
+        }
+        Ok(())
+    }
+
+    fn validate_arithmetic_operator(operator: &str, left_operand_column_metadata: &ContextualizerColumnMetadata, right_operand_column_metadata: &ContextualizerColumnMetadata) -> Result<(), String> {
+        
+        if left_operand_column_metadata.column_type() != right_operand_column_metadata.column_type() {
+            return Err(format!("The left-operand '{}' and right-operand '{}' must be same types to realizer the operation '{}'.", left_operand_column_metadata.column_name(), right_operand_column_metadata.column_name(), operator));
+        }
+
+        let common_type = left_operand_column_metadata.column_type();
+
+        if let Some(valid_operators) = VALID_ARITHMETIC_OPERATORS.get(&common_type) {
+            if !valid_operators.contains(&operator) {
+                return Err(format!("The left-operand '{}' and right-operand '{}' cannot be apply to the operation '{}'", left_operand_column_metadata.column_name(), right_operand_column_metadata.column_name(), operator));
+            } 
+        }
+
+        Ok(())
+    }
+
+    pub fn tokenize(text: &str, contextualizer: &ContextualizerMetadata) -> Result<Vec<Token>, String> {
+    
+        let mut tokens: Vec<Token> = Vec::new();
+
+        let mut previous_alias: HashSet<String> = HashSet::new();
+    
+        let splited: &[String] = &Self::split(text)?;
+
+        let metadata = contextualizer.get_context();
+
+        // [Context]
+        let context: Rc<RefCell<String>> = Rc::new(RefCell::new(String::new()));
+            
+        let mut tokens_iter = EventfulPeekable::new(
+            splited.iter(),
+            {
+                let context = Rc::clone(&context);
+                move |item| {
+                    context.borrow_mut().push_str(&format!(" {} ", item));
+                }
+            },
+        );
+
+        // [Parser state]: Tracks the last token type
+        enum LastToken {
+            None,
+            Comma,
+            Clause
+        }
+    
+        let mut last_token = LastToken::None;
+
+        let error_with_context = |message: String| -> String {
+            format!("{} [Context: {}]", message, context.borrow())
+        };
+    
+        while let Some(token) = tokens_iter.next() {
+            match token.as_str() {
+                "," => {
+                    match last_token {
+                        LastToken::Clause => {
+                            last_token = LastToken::Comma;
+                        },
+                        _ => {
+                            return Err(error_with_context(String::from("Comma must follow a property")));
+                        }
+                    }
+                },
+                _ => {
+                    match last_token {
+                        LastToken::None | LastToken::Comma => {
+
+                            // [Operation]
+                            let operation: Operation = match Self::get_operation(&metadata, &mut tokens_iter, &token) {
+                                Err(err) => return Err(error_with_context(err)),
+                                Ok(value) => value
+                            };
+                
+                            // [Alias]
+                            let alias_name = match &operation {
+                                Operation::Alias { operation } => &operation.alias_name,
+
+                                Operation::Arithmetic { operation } => match operation {
+                                    ArithmeticOperation::Addition { alias_name, .. } => alias_name,
+                                    ArithmeticOperation::Subtration { alias_name, .. } => alias_name,
+                                    ArithmeticOperation::Multiplication { alias_name, .. } => alias_name,
+                                    ArithmeticOperation::Division { alias_name, .. } => alias_name,
+                                    ArithmeticOperation::Module { alias_name, .. } => alias_name,
+                                }
+                            };
+
+                            if metadata.columns.contains_key(alias_name) {
+                                return Err(error_with_context(format!("The alias '{}' is reserved for an original table field with the same name.", alias_name)));
+                            }
+                        
+                            if previous_alias.contains(alias_name) {
+                                return Err(error_with_context(format!("The alias '{}' is already mapped.", alias_name)));
+                            }
+                            previous_alias.insert(alias_name.clone());
+
+                            // [Token]
+                            tokens.push(Token::new_operation(operation));
+
+                            last_token = LastToken::Clause;
+                        }
+                        _ => {
+                            return Err(error_with_context( String::from("Clause must follow a comma or be setted in begin")));
+                        }
+                    }
+                }
+            }
+        }
+        Ok(tokens)
+    }
+}

--- a/src/services/query/database/mssql/operations/count/context/context.rs
+++ b/src/services/query/database/mssql/operations/count/context/context.rs
@@ -1,0 +1,23 @@
+use std::any::TypeId;
+
+use crate::database::mssql::common::context::contextualizer::{ContextualizerColumnMetadata, ContextualizerMetadata};
+
+pub struct Context;
+
+impl Context {
+    pub fn resolve_context(
+        contextualizer: &mut ContextualizerMetadata,
+    ) -> Result<(), String> {  
+
+        let mut metadata = contextualizer.get_context();
+
+        let column_name = "count".to_string();
+        let column_type = TypeId::of::<i64>();
+
+        metadata.columns.insert(column_name.clone(), ContextualizerColumnMetadata::new(column_name, column_type));
+
+        contextualizer.update_context(metadata.clone());
+    
+        Ok(())
+    }
+}

--- a/src/services/query/database/mssql/operations/count/count.rs
+++ b/src/services/query/database/mssql/operations/count/count.rs
@@ -1,0 +1,60 @@
+use crate::{database::mssql::common::context::contextualizer::ContextualizerMetadata, services::query::common::alias_manager::QueryAliasManager};
+
+use super::context::context::Context;
+
+pub struct Count;
+
+impl Count {
+    pub fn process(
+        alias_manager: &mut QueryAliasManager,
+        contextualizer: &mut ContextualizerMetadata,
+    ) -> Result<String, String> {
+
+        let error = |message: String| -> String {
+            format!("Invalid $count: {}", message)
+        };
+
+        let sql = match Self::process_select(alias_manager, contextualizer) {
+            Err(err) => return Err(error(err)),
+            Ok(value) => value
+        };
+
+        match Context::resolve_context(contextualizer) {
+            Err(err) => return Err(error(err)),
+            Ok(value) => value
+        };
+
+        Ok(sql)
+    }
+
+    pub fn process_select(
+        alias_manager: &mut QueryAliasManager,
+        contextualizer: &mut ContextualizerMetadata,
+    ) -> Result<String, String> {
+
+        let mut sql: String = String::from("");
+
+        let metadata = contextualizer.get_context();
+
+        sql.push_str("SELECT\n");
+
+        let table_alias: String = alias_manager.get_or_create_table_alias(&metadata.table_name);
+
+        let column_name = "count".to_string();
+
+        let field_alias: String = alias_manager.get_or_create_field_alias(&column_name);
+            
+        sql.push_str(&format!(
+            "COUNT(*) AS [{}]",
+            field_alias
+        ));
+
+        sql.push_str("\n");
+
+        // [FROM clause]
+        sql.push_str("FROM\n");
+        sql.push_str(&format!("[{}] AS [{}]", metadata.table_name, table_alias));
+        
+        Ok(sql)
+    }
+}

--- a/src/services/query/database/mssql/operations/expand/expand.rs
+++ b/src/services/query/database/mssql/operations/expand/expand.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::services::query::common::alias_manager::QueryAliasManager;
 
-use crate::database::mssql::common::context::contextualizer::{ContextualizerEntityDescription, ContextualizerMetadata, ContextualizerRelationshipMetadata, ContextualizerRelationshipType};
+use crate::database::mssql::common::context::contextualizer::{ContextualizerMetadata, ContextualizerEntityDescription, ContextualizerRelationshipMetadata, ContextualizerRelationshipType};
 use crate::services::query::database::mssql::common::tokens::expand::token::Token;
 
 use super::{token::tokenization::Tokenization, context::context::Context};
@@ -16,16 +16,30 @@ impl Expand {
         contextualizer: &mut ContextualizerMetadata,
     ) -> Result<String, String> {
 
+        let error = |message: String| -> String {
+            format!("Invalid $expand: {}", message)
+        };
+
         let mut sql: String = String::from("");
         let mut tokens: Vec<Token> = Vec::new();
 
         if let Some(text) = text {
-            tokens = Tokenization::tokenize(text, contextualizer)?;
 
-            sql = Self::process_with_tokens(&tokens, alias_manager)?;
+            tokens = match Tokenization::tokenize(text, contextualizer) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
+
+            sql = match Self::process_with_tokens(&tokens, alias_manager) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
         }
 
-        Context::resolve_context(&tokens, contextualizer)?;
+        match Context::resolve_context(&tokens, contextualizer) {
+            Err(err) => return Err(error(err)),
+            Ok(value) => value
+        };
 
         Ok(sql)
     }

--- a/src/services/query/database/mssql/operations/expand/token/tokenization.rs
+++ b/src/services/query/database/mssql/operations/expand/token/tokenization.rs
@@ -117,7 +117,7 @@ impl Tokenization {
         let mut last_token = LastToken::None;
 
         let error_with_context = |message: String| -> String {
-            format!("Invalid $expand: {} [Context: {}]", message, context.borrow())
+            format!("{} [Context: {}]", message, context.borrow())
         };
     
         while let Some(token) = tokens_iter.next() {

--- a/src/services/query/database/mssql/operations/filter/compute/compute.rs
+++ b/src/services/query/database/mssql/operations/filter/compute/compute.rs
@@ -1,0 +1,599 @@
+use std::collections::HashMap;
+use lazy_static::lazy_static;
+
+use crate::services::query::common::alias_manager::QueryAliasManager;
+use crate::database::mssql::common::context::contextualizer::{ContextualizerColumnMetadata, ComputeArithmeticOperation, ComputeOperation};
+use crate::services::query::database::mssql::common::tokens::filter::token::Operation;
+
+#[derive(Hash, Eq, PartialEq, Debug)]
+enum OperationFilterType {
+    Equal,
+    NotEqual,
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual,
+    Like,
+    InValues,
+}
+
+lazy_static! {
+    static ref OPERATORS: HashMap<OperationFilterType, &'static str> = {
+        let mut map = HashMap::new();
+        map.insert(OperationFilterType::Equal, "=");
+        map.insert(OperationFilterType::NotEqual, "<>");
+        map.insert(OperationFilterType::GreaterThan, ">");
+        map.insert(OperationFilterType::GreaterThanOrEqual, ">=");
+        map.insert(OperationFilterType::LessThan, "<");
+        map.insert(OperationFilterType::LessThanOrEqual, "<=");
+        map.insert(OperationFilterType::Like, "LIKE");
+        map.insert(OperationFilterType::InValues, "IN");
+        map
+    };
+}
+
+#[derive(Hash, Eq, PartialEq, Debug)]
+enum ArithmeticOperationType {
+    Addition,
+    Subtration,
+    Multiplication,
+    Division,
+    Module
+}
+
+lazy_static! {
+    static ref ARITHMETIC_OPERATORS: HashMap<ArithmeticOperationType, &'static str> = {
+        let mut map = HashMap::new();
+        map.insert(ArithmeticOperationType::Addition, "+");
+        map.insert(ArithmeticOperationType::Subtration, "-");
+        map.insert(ArithmeticOperationType::Multiplication, "*");
+        map.insert(ArithmeticOperationType::Division, "/");
+        map.insert(ArithmeticOperationType::Module, "%");
+        map
+    };
+}
+
+pub struct Compute;
+
+impl Compute {
+    pub fn process_computed_column(
+        column_metadata: &ContextualizerColumnMetadata,
+        filter_operation: &Operation,
+        sql: &mut String,
+        alias_manager: &mut QueryAliasManager,
+    ) -> Result<(), String> {
+
+        let get_operator = |operator_type: &OperationFilterType| -> &'static str {
+            OPERATORS
+                .get(operator_type)
+                .ok_or_else(|| format!("Operator not found for {:?}", operator_type))
+                .unwrap()
+        };
+
+        match column_metadata {
+            ContextualizerColumnMetadata::Dynamic { specification, .. } => {
+                match &specification.operation_type {
+                    ComputeOperation::Alias { operation } => {
+
+                        let original_table = alias_manager.get_or_create_table_alias(&operation.table_name);
+                        let original_column_name = &operation.column_name;
+
+                        match &filter_operation {
+                            Operation::Equal { value } => {
+
+                                let operator = get_operator(&OperationFilterType::Equal);
+
+                                sql.push_str(&format!(
+                                    "([{}].[{}]) {} {}",
+                                    original_table, original_column_name, operator, value
+                                ));
+                            },
+                            Operation::NotEqual { value } => {
+
+                                let operator = get_operator(&OperationFilterType::NotEqual);
+
+                                sql.push_str(&format!(
+                                    "([{}].[{}]) {} {}",
+                                    original_table, original_column_name, operator, value
+                                ));
+                            },
+                            Operation::GreaterThan { value } => {
+
+                                let operator = get_operator(&OperationFilterType::GreaterThan);
+
+                                sql.push_str(&format!(
+                                    "([{}].[{}]) {} {}",
+                                    original_table, original_column_name, operator, value
+                                ));
+                            },
+                            Operation::GreaterThanOrEqual { value } => {
+
+                                let operator = get_operator(&OperationFilterType::GreaterThanOrEqual);
+
+                                sql.push_str(&format!(
+                                    "([{}].[{}]) {} {}",
+                                    original_table, original_column_name, operator, value
+                                ));
+                            },
+                            Operation::LessThan { value } => {
+
+                                let operator = get_operator(&OperationFilterType::LessThan);
+
+                                sql.push_str(&format!(
+                                    "([{}].[{}]) {} {}",
+                                    original_table, original_column_name, operator, value
+                                ));
+                            },
+                            Operation::LessThanOrEqual { value } => {
+
+                                let operator = get_operator(&OperationFilterType::LessThanOrEqual);
+
+                                sql.push_str(&format!(
+                                    "([{}].[{}]) {} {}",
+                                    original_table, original_column_name, operator, value
+                                ));
+                            },
+                            Operation::Like { value } => {
+
+                                let operator = get_operator(&OperationFilterType::Like);
+
+                                sql.push_str(&format!(
+                                    "([{}].[{}]) {} {}",
+                                    original_table, original_column_name, operator, value
+                                ));
+                            },
+                            Operation::InValues { value } => {
+
+                                let operator = get_operator(&OperationFilterType::InValues);
+
+                                sql.push_str(&format!(
+                                    "([{}].[{}]) {} {}",
+                                    original_table, original_column_name, operator, value.join(",")
+                                ));
+                            },
+                        }
+        
+                    },
+                    ComputeOperation::Arithmetic { operation } => {
+                        let get_arithmetic_operator = |arithmetic_operator_type: &ArithmeticOperationType| -> &'static str {
+                            ARITHMETIC_OPERATORS
+                                .get(arithmetic_operator_type)
+                                .ok_or_else(|| format!("Invalid $compute: Arithmetic operator not found for {:?}", arithmetic_operator_type))
+                                .unwrap()
+                        };
+        
+                        match operation {
+                            ComputeArithmeticOperation::Addition { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Addition);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+              
+                                match &filter_operation {
+                                    Operation::Equal { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Equal);
+          
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::NotEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::NotEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::Like { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Like);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::InValues { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::InValues);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} ({})",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value.join(",")
+                                        ));
+                                    },
+                                }
+                            },
+                            ComputeArithmeticOperation::Subtration { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Subtration);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+              
+                                match &filter_operation {
+                                    Operation::Equal { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Equal);
+          
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::NotEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::NotEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::Like { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Like);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::InValues { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::InValues);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} ({})",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value.join(",")
+                                        ));
+                                    },
+                                }
+                            },
+                            ComputeArithmeticOperation::Multiplication { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Multiplication);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+              
+                                match &filter_operation {
+                                    Operation::Equal { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Equal);
+          
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::NotEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::NotEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::Like { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Like);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::InValues { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::InValues);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} ({})",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value.join(",")
+                                        ));
+                                    },
+                                }
+                            },
+                            ComputeArithmeticOperation::Division { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Division);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+              
+                                match &filter_operation {
+                                    Operation::Equal { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Equal);
+          
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::NotEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::NotEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::Like { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Like);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::InValues { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::InValues);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} ({})",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value.join(",")
+                                        ));
+                                    },
+                                }
+                            }
+                            ComputeArithmeticOperation::Module { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Module);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+              
+                                match &filter_operation {
+                                    Operation::Equal { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Equal);
+          
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::NotEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::NotEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::GreaterThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThan { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThan);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::LessThanOrEqual { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::LessThanOrEqual);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::Like { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::Like);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} {}",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value
+                                        ));
+                                    },
+                                    Operation::InValues { value } => {
+                                    
+                                        let filter_operator = get_operator(&OperationFilterType::InValues);
+                                    
+                                        sql.push_str(&format!(
+                                            "([{}].[{}] {} [{}].[{}]) {} ({})",
+                                            left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, filter_operator, value.join(",")
+                                        ));
+                                    },
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            _ => return Err(String::from("Provide only computed columns to 'process_computed_column'"))
+        }
+        Ok(())
+    }
+}

--- a/src/services/query/database/mssql/operations/filter/filter.rs
+++ b/src/services/query/database/mssql/operations/filter/filter.rs
@@ -2,11 +2,10 @@ use std::collections::HashMap;
 use lazy_static::lazy_static;
 
 use crate::services::query::common::alias_manager::QueryAliasManager;
+use crate::database::mssql::common::context::contextualizer::{ContextualizerMetadata, ContextualizerColumnMetadata};
+use crate::services::query::database::mssql::common::tokens::filter::token::{Increment, Operation, Parentheses, Token};
 
-use crate::database::mssql::common::context::contextualizer::ContextualizerMetadata;
-use crate::services::query::database::mssql::common::tokens::filter::token::{Token, Parentheses, Increment, Operation};
-
-use super::token::tokenization::Tokenization;
+use super::{compute::compute::Compute, token::tokenization::Tokenization};
 
 #[derive(Hash, Eq, PartialEq, Debug)]
 enum OperationFilterType {
@@ -44,13 +43,22 @@ impl Filter {
         contextualizer: &ContextualizerMetadata,
     ) -> Result<String, String> {
 
+        let error = |message: String| -> String {
+            format!("Invalid $filter: {}", message)
+        };
+
         let mut sql: String = String::from("");
-        let mut tokens: Vec<Token> = Vec::new();
 
         if let Some(text) = text {
-            tokens = Tokenization::tokenize(text, contextualizer)?;
+            let tokens = match Tokenization::tokenize(text, contextualizer) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
 
-            sql = Self::process_with_tokens(&tokens, alias_manager)?;
+            sql = match Self::process_with_tokens(&tokens, alias_manager){
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
         }
 
         // [There no changes in context for while...]
@@ -70,13 +78,19 @@ impl Filter {
         let get_operator = |operator_type: &OperationFilterType| -> &'static str {
             OPERATORS
                 .get(operator_type)
-                .ok_or_else(|| format!("Invalid $filter: Operator not found for {:?}", operator_type))
+                .ok_or_else(|| format!("Operator not found for {:?}", operator_type))
                 .unwrap()
         };
 
+        let mut needs_space = false;
+
         for token in tokens {
 
-            sql.push_str(" ");
+            if needs_space {
+                sql.push(' ');
+
+                needs_space = false;
+            }
 
             match token {
                 Token::Parentheses { parentheses } => {
@@ -91,88 +105,102 @@ impl Filter {
                     }
                 },
                 Token::Increment { increment } => {
+
+                    needs_space = true;
+
                     match increment {
                         Increment::And => sql.push_str("OR"),
                         Increment::Or => sql.push_str("AND")
                     }
                 },
                 Token::Property { metadata, column_metadata, operation } => {
-                    let alias = alias_manager.get_or_create_table_alias(&metadata.table_name);
+                    
+                    needs_space = true;
 
-                    match &operation {
-                        Operation::Equal { value } => {
+                    match column_metadata {
+                        ContextualizerColumnMetadata::Original { column_name, .. } => {
 
-                            let operator = get_operator(&OperationFilterType::Equal);
+                            let alias = alias_manager.get_or_create_table_alias(&metadata.table_name);
 
-                            sql.push_str(&format!(
-                                "[{}].[{}] {} {}",
-                                alias, column_metadata.column_name, operator, value
-                            ));
+                                match &operation {
+                                    Operation::Equal { value } => {
+
+                                        let operator = get_operator(&OperationFilterType::Equal);
+
+                                        sql.push_str(&format!(
+                                            "[{}].[{}] {} {}",
+                                            alias, column_name, operator, value
+                                        ));
+                                    },
+                                    Operation::NotEqual { value } => {
+
+                                        let operator = get_operator(&OperationFilterType::NotEqual);
+
+                                        sql.push_str(&format!(
+                                            "[{}].[{}] {} {}",
+                                            alias, column_name, operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThan { value } => {
+
+                                        let operator = get_operator(&OperationFilterType::GreaterThan);
+
+                                        sql.push_str(&format!(
+                                            "[{}].[{}] {} {}",
+                                            alias, column_name, operator, value
+                                        ));
+                                    },
+                                    Operation::GreaterThanOrEqual { value } => {
+
+                                        let operator = get_operator(&OperationFilterType::GreaterThanOrEqual);
+
+                                        sql.push_str(&format!(
+                                            "[{}].[{}] {} {}",
+                                            alias, column_name, operator, value
+                                        ));
+                                    },
+                                    Operation::LessThan { value } => {
+
+                                        let operator = get_operator(&OperationFilterType::LessThan);
+
+                                        sql.push_str(&format!(
+                                            "[{}].[{}] {} {}",
+                                            alias, column_name, operator, value
+                                        ));
+                                    },
+                                    Operation::LessThanOrEqual { value } => {
+                                        
+                                        let operator = get_operator(&OperationFilterType::LessThanOrEqual);
+
+                                        sql.push_str(&format!(
+                                            "[{}].[{}] {} {}",
+                                            alias, column_name, operator, value
+                                        ));
+                                    },
+                                    Operation::Like { value } => {
+                                        
+                                        let operator = get_operator(&OperationFilterType::Like);
+
+                                        sql.push_str(&format!(
+                                            "[{}].[{}] {} {}",
+                                            alias, column_name, operator, value
+                                        ));
+                                    },
+                                    Operation::InValues { value } => {
+
+                                        let operator = get_operator(&OperationFilterType::InValues);
+
+                                        sql.push_str(&format!(
+                                            "[{}].[{}] {} ({})",
+                                            alias, column_name, operator, value.join(",")
+                                        ));
+                                    },
+                                }
                         },
-                        Operation::NotEqual { value } => {
-
-                            let operator = get_operator(&OperationFilterType::NotEqual);
-
-                            sql.push_str(&format!(
-                                "[{}].[{}] {} {}",
-                                alias, column_metadata.column_name, operator, value
-                            ));
-                        },
-                        Operation::GreaterThan { value } => {
-
-                            let operator = get_operator(&OperationFilterType::GreaterThan);
-
-                            sql.push_str(&format!(
-                                "[{}].[{}] {} {}",
-                                alias, column_metadata.column_name, operator, value
-                            ));
-                        },
-                        Operation::GreaterThanOrEqual { value } => {
-
-                            let operator = get_operator(&OperationFilterType::GreaterThanOrEqual);
-
-                            sql.push_str(&format!(
-                                "[{}].[{}] {} {}",
-                                alias, column_metadata.column_name, operator, value
-                            ));
-                        },
-                        Operation::LessThan { value } => {
-
-                            let operator = get_operator(&OperationFilterType::LessThan);
-
-                            sql.push_str(&format!(
-                                "[{}].[{}] {} {}",
-                                alias, column_metadata.column_name, operator, value
-                            ));
-                        },
-                        Operation::LessThanOrEqual { value } => {
-                            
-                            let operator = get_operator(&OperationFilterType::LessThanOrEqual);
-
-                            sql.push_str(&format!(
-                                "[{}].[{}] {} {}",
-                                alias, column_metadata.column_name, operator, value
-                            ));
-                        },
-                        Operation::Like { value } => {
-                            
-                            let operator = get_operator(&OperationFilterType::Like);
-
-                            sql.push_str(&format!(
-                                "[{}].[{}] {} {}",
-                                alias, column_metadata.column_name, operator, value
-                            ));
-                        },
-                        Operation::InValues { value } => {
-
-                            let operator = get_operator(&OperationFilterType::InValues);
-
-                            sql.push_str(&format!(
-                                "[{}].[{}] {} ({})",
-                                alias, column_metadata.column_name, operator, value.join(",")
-                            ));
-                        },
-                    }
+                        ContextualizerColumnMetadata::Dynamic { .. } => { 
+                            Compute::process_computed_column(column_metadata, operation, &mut sql, alias_manager)?
+                        } 
+                    }  
                 },
             }
         }

--- a/src/services/query/database/mssql/operations/filter/token/tokenization.rs
+++ b/src/services/query/database/mssql/operations/filter/token/tokenization.rs
@@ -4,7 +4,7 @@ use chrono::{NaiveDate, NaiveDateTime};
 use dynamic_queries_api::EventfulPeekable;
 
 use crate::database::mssql::common::context::contextualizer::{ContextualizerMetadata, ContextualizerEntityDescription, ContextualizerColumnMetadata};
-use crate::services::query::database::mssql::common::tokens::filter::token::{Token, Increment, Operation, Parentheses};
+use crate::services::query::database::mssql::common::tokens::filter::token::{Token, Parentheses, Increment, Operation};
 
 lazy_static! {
     static ref OPERATORS: HashSet<&'static str> = {
@@ -56,34 +56,34 @@ pub struct Tokenization;
 
 impl Tokenization {
     fn format_value(value: &str, column_metadata: &ContextualizerColumnMetadata) -> Result<String, String> {
-        let is_nullable = column_metadata.column_type == TypeId::of::<Option<i32>>()
-            || column_metadata.column_type == TypeId::of::<Option<i64>>()
-            || column_metadata.column_type == TypeId::of::<Option<f32>>()
-            || column_metadata.column_type == TypeId::of::<Option<f64>>()
-            || column_metadata.column_type == TypeId::of::<Option<bool>>()
-            || column_metadata.column_type == TypeId::of::<Option<String>>()
-            || column_metadata.column_type == TypeId::of::<Option<NaiveDate>>()
-            || column_metadata.column_type == TypeId::of::<Option<NaiveDateTime>>();
+        let is_nullable = column_metadata.column_type() == TypeId::of::<Option<i32>>()
+            || column_metadata.column_type() == TypeId::of::<Option<i64>>()
+            || column_metadata.column_type() == TypeId::of::<Option<f32>>()
+            || column_metadata.column_type() == TypeId::of::<Option<f64>>()
+            || column_metadata.column_type() == TypeId::of::<Option<bool>>()
+            || column_metadata.column_type() == TypeId::of::<Option<String>>()
+            || column_metadata.column_type() == TypeId::of::<Option<NaiveDate>>()
+            || column_metadata.column_type() == TypeId::of::<Option<NaiveDateTime>>();
     
         match value {
             "None" if is_nullable => Ok(String::from("NULL")),
             "None" => Err(format!(
                 "None value not allowed for non-nullable column: {}",
-                column_metadata.column_name
+                column_metadata.column_name()
             )),
-            _ => match column_metadata.column_type {
+            _ => match column_metadata.column_type() {
 
-                _ if column_metadata.column_type == TypeId::of::<Option<i32>>() ||
-                     column_metadata.column_type == TypeId::of::<Option<i64>>() ||
-                     column_metadata.column_type == TypeId::of::<Option<f32>>() ||
-                     column_metadata.column_type == TypeId::of::<Option<f64>>() => {
+                _ if column_metadata.column_type() == TypeId::of::<Option<i32>>() ||
+                     column_metadata.column_type() == TypeId::of::<Option<i64>>() ||
+                     column_metadata.column_type() == TypeId::of::<Option<f32>>() ||
+                     column_metadata.column_type() == TypeId::of::<Option<f64>>() => {
                         value.parse::<f64>().map_or_else(
                         |_| Err(format!("Invalid numeric value: {}", value)),
                         |_| Ok(value.to_string())
                     )
                 }
     
-                _ if column_metadata.column_type == TypeId::of::<Option<bool>>() => {
+                _ if column_metadata.column_type() == TypeId::of::<Option<bool>>() => {
                     match value.to_lowercase().as_str() {
                         "true" => Ok(String::from("TRUE")),
                         "false" => Ok(String::from("FALSE")),
@@ -91,9 +91,9 @@ impl Tokenization {
                     }
                 }
     
-                _ if column_metadata.column_type == TypeId::of::<Option<String>>() ||
-                     column_metadata.column_type == TypeId::of::<Option<NaiveDate>>() ||
-                     column_metadata.column_type == TypeId::of::<Option<NaiveDateTime>>() => {
+                _ if column_metadata.column_type() == TypeId::of::<Option<String>>() ||
+                     column_metadata.column_type() == TypeId::of::<Option<NaiveDate>>() ||
+                     column_metadata.column_type() == TypeId::of::<Option<NaiveDateTime>>() => {
                     if value.starts_with("'") && value.ends_with("'") {
                         Ok(value.to_string())
                     } else {
@@ -101,10 +101,10 @@ impl Tokenization {
                     }
                 }
 
-                _ if column_metadata.column_type == TypeId::of::<i32>() ||
-                     column_metadata.column_type == TypeId::of::<i64>() ||
-                     column_metadata.column_type == TypeId::of::<f32>() ||
-                     column_metadata.column_type == TypeId::of::<f64>() => {
+                _ if column_metadata.column_type() == TypeId::of::<i32>() ||
+                     column_metadata.column_type() == TypeId::of::<i64>() ||
+                     column_metadata.column_type() == TypeId::of::<f32>() ||
+                     column_metadata.column_type() == TypeId::of::<f64>() => {
 
                         value.parse::<f64>().map_or_else(
                         |_| Err(format!("Invalid numeric value: {}", value)),
@@ -112,7 +112,7 @@ impl Tokenization {
                     )
                 }
     
-                _ if column_metadata.column_type == TypeId::of::<bool>() => {
+                _ if column_metadata.column_type() == TypeId::of::<bool>() => {
                     match value.to_lowercase().as_str() {
                         "true" => Ok(String::from("TRUE")),
                         "false" => Ok(String::from("FALSE")),
@@ -120,9 +120,9 @@ impl Tokenization {
                     }
                 }
     
-                _ if column_metadata.column_type == TypeId::of::<String>() ||
-                     column_metadata.column_type == TypeId::of::<NaiveDate>() ||
-                     column_metadata.column_type == TypeId::of::<NaiveDateTime>() => {
+                _ if column_metadata.column_type() == TypeId::of::<String>() ||
+                     column_metadata.column_type() == TypeId::of::<NaiveDate>() ||
+                     column_metadata.column_type() == TypeId::of::<NaiveDateTime>() => {
                     if value.starts_with("'") && value.ends_with("'") {
                         Ok(value.to_string())
                     } else {
@@ -130,7 +130,7 @@ impl Tokenization {
                     }
                 }
     
-                _ => Err(format!("Unsupported column type for {}", column_metadata.column_name)),
+                _ => Err(format!("Unsupported column type for {}", column_metadata.column_name())),
             },
         }
     }
@@ -263,7 +263,7 @@ impl Tokenization {
 
     fn get_operation(column_metadata: &ContextualizerColumnMetadata, tokens_iter: &mut EventfulPeekable<std::slice::Iter<'_, String>>) -> Result<Operation, String> {
 
-        let operator: &str = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {}", column_metadata.column_name))?; 
+        let operator: &str = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {}", column_metadata.column_name()))?; 
 
         Self::validate_operator(operator, column_metadata)?;
 
@@ -283,7 +283,7 @@ impl Tokenization {
             }
             
             if parentheses_depth != 0 {
-                return Err(format!("Unbalanced parentheses in 'in clause': {} : {}", column_metadata.column_name, operator));
+                return Err(format!("Unbalanced parentheses in 'in clause': {} : {}", column_metadata.column_name(), operator));
             }
 
             // [Formatting  and Validation of values]
@@ -296,14 +296,14 @@ impl Tokenization {
             }
 
             if values.len() == 0 {
-                return Err(format!("'in clause' must have values: {} : {}", column_metadata.column_name, operator));
+                return Err(format!("'in clause' must have values: {} : {}", column_metadata.column_name(), operator));
             }
 
             return Ok(Operation::in_values(values))
         }
 
         // [Formatting and Validation of values]
-        let non_formatted_value = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {} : {}", column_metadata.column_name, operator))?;
+        let non_formatted_value = tokens_iter.next().ok_or_else(|| format!("Invalid format near token: {} : {}", column_metadata.column_name(), operator))?;
 
         let value: String = Self::format_value(non_formatted_value, column_metadata)?;
 
@@ -315,7 +315,7 @@ impl Tokenization {
             "lt" => Operation::less_than(value),
             "le" => Operation::less_than_or_equal(value),
             "like" => Operation::like(value),
-            _ => return Err(format!("Unsupported operator: {} : {}", column_metadata.column_name, operator)),
+            _ => return Err(format!("Unsupported operator: {} : {}", column_metadata.column_name(), operator)),
         };
         
         Ok(operation)
@@ -326,7 +326,7 @@ impl Tokenization {
             return Err(format!("Operator '{}' is not a valid operator", operator));
         }
 
-        if let Some(valid_operators) = VALID_OPERATORS.get(&column_metadata.column_type) {
+        if let Some(valid_operators) = VALID_OPERATORS.get(&column_metadata.column_type()) {
             if valid_operators.contains(&operator) {
                 return Ok(());
             } else {
@@ -370,7 +370,7 @@ impl Tokenization {
         let mut last_token = LastToken::None;
 
         let error_with_context = |message: String| -> String {
-            format!("Invalid $filter: {} [Context: {}]", message, context.borrow())
+            format!("{} [Context: {}]", message, context.borrow())
         };
     
         while let Some(token) = tokens_iter.next() {

--- a/src/services/query/database/mssql/operations/orderby/compute/compute.rs
+++ b/src/services/query/database/mssql/operations/orderby/compute/compute.rs
@@ -1,0 +1,144 @@
+use std::collections::HashMap;
+use lazy_static::lazy_static;
+
+use crate::services::query::common::alias_manager::QueryAliasManager;
+use crate::database::mssql::common::context::contextualizer::{ContextualizerColumnMetadata, ComputeArithmeticOperation, ComputeOperation};
+
+#[derive(Hash, Eq, PartialEq, Debug)]
+enum ArithmeticOperationType {
+    Addition,
+    Subtration,
+    Multiplication,
+    Division,
+    Module
+}
+
+lazy_static! {
+    static ref ARITHMETIC_OPERATORS: HashMap<ArithmeticOperationType, &'static str> = {
+        let mut map = HashMap::new();
+        map.insert(ArithmeticOperationType::Addition, "+");
+        map.insert(ArithmeticOperationType::Subtration, "-");
+        map.insert(ArithmeticOperationType::Multiplication, "*");
+        map.insert(ArithmeticOperationType::Division, "/");
+        map.insert(ArithmeticOperationType::Module, "%");
+        map
+    };
+}
+
+pub struct Compute;
+
+impl Compute {
+    pub fn process_computed_column(
+        column_metadata: &ContextualizerColumnMetadata,
+        properties: &mut Vec<String>,
+        alias_manager: &mut QueryAliasManager,
+    ) -> Result<(), String> {
+
+        match column_metadata {
+            ContextualizerColumnMetadata::Dynamic { specification, .. } => {
+                match &specification.operation_type {
+                    ComputeOperation::Alias { operation } => {
+        
+                        let original_table = alias_manager.get_or_create_table_alias(&operation.table_name);
+                        let original_column_name = &operation.column_name;
+           
+                        properties.push(format!(
+                            "([{}].[{}])", 
+                            original_table, original_column_name
+                        ));
+        
+                    },
+                    ComputeOperation::Arithmetic { operation } => {
+                        let get_arithmetic_operator = |arithmetic_operator_type: &ArithmeticOperationType| -> &'static str {
+                            ARITHMETIC_OPERATORS
+                                .get(arithmetic_operator_type)
+                                .ok_or_else(|| format!("Invalid $compute: Arithmetic operator not found for {:?}", arithmetic_operator_type))
+                                .unwrap()
+                        };
+        
+                        match operation {
+                            ComputeArithmeticOperation::Addition { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Addition);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+        
+       
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}])", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name
+                                ));
+                            },
+                            ComputeArithmeticOperation::Subtration { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Subtration);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+               
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}])", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name
+                                ));
+                            },
+                            ComputeArithmeticOperation::Multiplication { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Multiplication);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+                
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}])", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name
+                                ));
+                            },
+                            ComputeArithmeticOperation::Division { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Division);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+                
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}])", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name
+                                ));
+                            },
+                            ComputeArithmeticOperation::Module { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Module);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+                
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}])", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name
+                                ));
+                            }
+                        }
+                    }
+                }
+            },
+            _ => return Err(String::from("Provide only computed columns to 'process_computed_column'"))
+        }
+        Ok(())
+    }
+}

--- a/src/services/query/database/mssql/operations/orderby/orderby.rs
+++ b/src/services/query/database/mssql/operations/orderby/orderby.rs
@@ -1,9 +1,9 @@
 use crate::services::query::common::alias_manager::QueryAliasManager;
 
-use crate::database::mssql::common::context::contextualizer::ContextualizerMetadata;
+use crate::database::mssql::common::context::contextualizer::{ContextualizerMetadata, ContextualizerColumnMetadata};
 use crate::services::query::database::mssql::common::tokens::orderby::token::Token;
 
-use super::token::tokenization::Tokenization;
+use super::{compute::compute::Compute, token::tokenization::Tokenization};
 
 pub struct Orderby;
 
@@ -14,13 +14,22 @@ impl Orderby {
         contextualizer: &ContextualizerMetadata,
     ) -> Result<String, String> {
 
+        let error = |message: String| -> String {
+            format!("Invalid $orderby: {}", message)
+        };
+
         let mut sql: String = String::from("");
-        let mut tokens: Vec<Token> = Vec::new();
 
         if let Some(text) = text {
-            tokens = Tokenization::tokenize(text, contextualizer)?;
+            let tokens = match Tokenization::tokenize(text, contextualizer) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
 
-            sql = Self::process_with_tokens(&tokens, alias_manager)?;
+            sql = match Self::process_with_tokens(&tokens, alias_manager) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
         }
 
         // [There no changes in context for while...]
@@ -42,12 +51,20 @@ impl Orderby {
         for token in tokens {
             match token {
                 Token::Property { metadata, column_metadata } => {
-                    let table_alias = alias_manager.get_or_create_table_alias(&metadata.table_name);
+                    match column_metadata {
+                        ContextualizerColumnMetadata::Original { column_name, .. } => {
+
+                            let table_alias = alias_manager.get_or_create_table_alias(&metadata.table_name);
                     
-                    properties.push(format!(
-                        "[{}].[{}]",
-                        table_alias, column_metadata.column_name
-                    ));
+                            properties.push(format!(
+                                "[{}].[{}]",
+                                table_alias, column_name
+                            ));
+                        },
+                        ContextualizerColumnMetadata::Dynamic { .. } => { 
+                            Compute::process_computed_column(&column_metadata, &mut properties, alias_manager)?
+                        } 
+                    }
                 },
             }
         }

--- a/src/services/query/database/mssql/operations/orderby/token/tokenization.rs
+++ b/src/services/query/database/mssql/operations/orderby/token/tokenization.rs
@@ -130,7 +130,7 @@ impl Tokenization {
         let mut last_token = LastToken::None;
 
         let error_with_context = |message: String| -> String {
-            format!("Invalid $orderby: {} [Context: {}]", message, context.borrow())
+            format!("{} [Context: {}]", message, context.borrow())
         };
     
         while let Some(token) = tokens_iter.next() {

--- a/src/services/query/database/mssql/operations/select/compute/compute.rs
+++ b/src/services/query/database/mssql/operations/select/compute/compute.rs
@@ -1,0 +1,155 @@
+use std::collections::HashMap;
+use lazy_static::lazy_static;
+
+use crate::services::query::common::alias_manager::QueryAliasManager;
+use crate::database::mssql::common::context::contextualizer::{ContextualizerColumnMetadata, ComputeArithmeticOperation, ComputeOperation};
+
+#[derive(Hash, Eq, PartialEq, Debug)]
+enum ArithmeticOperationType {
+    Addition,
+    Subtration,
+    Multiplication,
+    Division,
+    Module
+}
+
+lazy_static! {
+    static ref ARITHMETIC_OPERATORS: HashMap<ArithmeticOperationType, &'static str> = {
+        let mut map = HashMap::new();
+        map.insert(ArithmeticOperationType::Addition, "+");
+        map.insert(ArithmeticOperationType::Subtration, "-");
+        map.insert(ArithmeticOperationType::Multiplication, "*");
+        map.insert(ArithmeticOperationType::Division, "/");
+        map.insert(ArithmeticOperationType::Module, "%");
+        map
+    };
+}
+
+pub struct Compute;
+
+impl Compute {
+    pub fn process_computed_column(
+        column_metadata: &ContextualizerColumnMetadata,
+        properties: &mut Vec<String>,
+        alias_manager: &mut QueryAliasManager,
+    ) -> Result<(), String> {
+
+        match column_metadata {
+            ContextualizerColumnMetadata::Dynamic { column_name, specification, .. } => {
+                match &specification.operation_type {
+                    ComputeOperation::Alias { operation } => {
+        
+                        let original_table = alias_manager.get_or_create_table_alias(&operation.table_name);
+                        let original_column_name = &operation.column_name;
+        
+                        let alias_column_name = alias_manager.get_or_create_field_alias(&column_name);
+        
+                        properties.push(format!(
+                            "[{}].[{}] AS [{}]", 
+                            original_table, original_column_name, alias_column_name
+                        ));
+        
+                    },
+                    ComputeOperation::Arithmetic { operation } => {
+                        let get_arithmetic_operator = |arithmetic_operator_type: &ArithmeticOperationType| -> &'static str {
+                            ARITHMETIC_OPERATORS
+                                .get(arithmetic_operator_type)
+                                .ok_or_else(|| format!("Invalid $compute: Arithmetic operator not found for {:?}", arithmetic_operator_type))
+                                .unwrap()
+                        };
+        
+                        match operation {
+                            ComputeArithmeticOperation::Addition { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Addition);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+        
+                                let alias_column_name = alias_manager.get_or_create_field_alias(&column_name);
+        
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}]) AS [{}]", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, alias_column_name
+                                ));
+                            },
+                            ComputeArithmeticOperation::Subtration { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Subtration);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+        
+                                let alias_column_name = alias_manager.get_or_create_field_alias(&column_name);
+        
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}]) AS [{}]", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, alias_column_name
+                                ));
+                            },
+                            ComputeArithmeticOperation::Multiplication { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Multiplication);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+        
+                                let alias_column_name = alias_manager.get_or_create_field_alias(&column_name);
+        
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}]) AS [{}]", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, alias_column_name
+                                ));
+                            },
+                            ComputeArithmeticOperation::Division { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Division);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+        
+                                let alias_column_name = alias_manager.get_or_create_field_alias(&column_name);
+        
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}]) AS [{}]", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, alias_column_name
+                                ));
+                            },
+                            ComputeArithmeticOperation::Module { left_operand, right_operand} => {
+                                
+                                let operator = get_arithmetic_operator(&ArithmeticOperationType::Module);
+        
+                                let left_operand_table = alias_manager.get_or_create_table_alias(&left_operand.table_name);
+                                let left_operand_column_name = &left_operand.column_name;
+        
+                                let right_operand_table = alias_manager.get_or_create_table_alias(&right_operand.table_name);
+                                let right_operand_column_name = &right_operand.column_name;
+        
+                                let alias_column_name = alias_manager.get_or_create_field_alias(&column_name);
+        
+                                properties.push(format!(
+                                    "([{}].[{}] {} [{}].[{}]) AS [{}]", 
+                                    left_operand_table, left_operand_column_name, operator, right_operand_table, right_operand_column_name, alias_column_name
+                                ));
+                            }
+                        }
+                    }
+                }
+            },
+            _ => return Err(String::from("Provide only computed columns to 'process_computed_column'"))
+        }
+        Ok(())
+    }
+}

--- a/src/services/query/database/mssql/operations/select/select.rs
+++ b/src/services/query/database/mssql/operations/select/select.rs
@@ -1,9 +1,9 @@
 use crate::services::query::common::alias_manager::QueryAliasManager;
 
-use crate::database::mssql::common::context::contextualizer::ContextualizerMetadata;
+use crate::database::mssql::common::context::contextualizer::{ContextualizerMetadata, ContextualizerColumnMetadata};
 use crate::services::query::database::mssql::common::tokens::select::token::Token;
 
-use super::token::tokenization::Tokenization;
+use super::{compute::compute::Compute, token::tokenization::Tokenization};
 
 pub struct Select;
 
@@ -14,16 +14,29 @@ impl Select {
         contextualizer: &ContextualizerMetadata,
     ) -> Result<String, String> {
 
-        let mut sql: String = String::from("");
-        let mut tokens: Vec<Token> = Vec::new();
+        let error = |message: String| -> String {
+            format!("Invalid $select: {}", message)
+        };
+
+        let sql: String;
 
         if let Some(text) = text {
-            tokens = Tokenization::tokenize(text, contextualizer)?;
 
-            sql = Self::process_with_tokens(&tokens, alias_manager, contextualizer)?;
+            let tokens = match Tokenization::tokenize(text, contextualizer) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
+
+            sql = match Self::process_with_tokens(&tokens, alias_manager, contextualizer) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };
         }
         else {
-            sql = Self::process_without_tokens(alias_manager, contextualizer)?  
+            sql = match Self::process_without_tokens(alias_manager, contextualizer) {
+                Err(err) => return Err(error(err)),
+                Ok(value) => value
+            };  
         }
 
         // [There no changes in context for while...]
@@ -47,11 +60,11 @@ impl Select {
         let table_alias: String = alias_manager.get_or_create_table_alias(&metadata.table_name);
 
         for column_metadata in metadata.columns.values() {
-            let field_alias: String = alias_manager.get_or_create_field_alias(&column_metadata.column_name);
+            let field_alias: String = alias_manager.get_or_create_field_alias(&column_metadata.column_name());
             
             properties.push(format!(
                 "[{}].[{}] AS [{}]",
-                table_alias, column_metadata.column_name, field_alias
+                table_alias, column_metadata.column_name(), field_alias
             ));
         }
 
@@ -83,14 +96,22 @@ impl Select {
         for token in tokens {
             match token {
                 Token::Property { metadata, column_metadata, relation_path} => {
-                    let table_alias = alias_manager.get_or_create_table_alias(&metadata.table_name);
-                    let field_alias = alias_manager.get_or_create_field_alias(&relation_path);
-                    
-                    properties.push(format!(
-                        "[{}].[{}] AS [{}]", 
-                        table_alias, column_metadata.column_name, field_alias
-                    ));
-                },
+                    match column_metadata {
+                        ContextualizerColumnMetadata::Original { column_name, .. } => {
+
+                            let table_alias = alias_manager.get_or_create_table_alias(&metadata.table_name);
+                            let field_alias = alias_manager.get_or_create_field_alias(&relation_path);
+                            
+                            properties.push(format!(
+                                "[{}].[{}] AS [{}]", 
+                                table_alias, column_name, field_alias
+                            ));
+                        },
+                        ContextualizerColumnMetadata::Dynamic { .. } => { 
+                            Compute::process_computed_column(&column_metadata, &mut properties, alias_manager)?
+                        } 
+                    }
+                }
             }
         }
 

--- a/src/services/query/database/mssql/operations/select/token/tokenization.rs
+++ b/src/services/query/database/mssql/operations/select/token/tokenization.rs
@@ -130,7 +130,7 @@ impl Tokenization {
         let mut last_token = LastToken::None;
 
         let error_with_context = |message: String| -> String {
-            format!("Invalid $select: {} [Context: {}]", message, context.borrow())
+            format!("{} [Context: {}]", message, context.borrow())
         };
     
         while let Some(token) = tokens_iter.next() {

--- a/src/services/query/database/mssql/query.rs
+++ b/src/services/query/database/mssql/query.rs
@@ -3,6 +3,8 @@ use crate::dto::query_params::QueryParams;
 
 use crate::database::mssql::common::context::contextualizer::ContextualizerMetadata;
 
+use crate::services::query::database::mssql::operations::compute::compute::Compute;
+use crate::services::query::database::mssql::operations::count::count::Count;
 use crate::services::query::database::mssql::operations::select::select::Select;
 use crate::services::query::database::mssql::operations::filter::filter::Filter;
 use crate::services::query::database::mssql::operations::expand::expand::Expand;
@@ -22,6 +24,9 @@ impl Query {
 
         // [$expand (With context changes)]
         let expand_text = Expand::process(options.expand.as_deref(), query_alias_manager, contextualizer)?;
+
+        // [$compute (With context changes)]
+        Compute::process(options.compute.as_deref(), contextualizer)?;
 
         // [$select (Without context changes)]
         let select_text = Select::process(options.select.as_deref(), query_alias_manager, contextualizer)?;
@@ -44,18 +49,70 @@ impl Query {
             skip_text = Skip::process(text)?;
         }
 
-        let sql = format!(
-            "{}\n{}\n{}\n{}\n{}\n{}",
-            select_text,
-            expand_text,
-            filter_text,
-            orderby_text,
-            top_text,
-            skip_text
+        let mut sql = String::with_capacity(
+            select_text.len() + expand_text.len() + filter_text.len() + orderby_text.len() + top_text.len() + skip_text.len() + 4,
         );
+        
+        for text in [select_text, expand_text, filter_text, orderby_text, top_text, skip_text] {
+            if !text.is_empty() {
+                if !sql.is_empty() {
+                    sql.push('\n');
+                }
+                sql.push_str(text.as_str());
+            }
+        }
 
-        println!("Final query: \n{}", sql);
+        println!("\n{}", sql);
         
         Ok(sql)
-    }    
+    }  
+
+    pub fn build_query_count(
+        &self,
+        options: &QueryParams,
+        query_alias_manager: &mut QueryAliasManager,
+        contextualizer: &mut ContextualizerMetadata,
+    ) -> Result<String, String> {
+
+        // [$expand (With context changes)]
+        let expand_text = Expand::process(options.expand.as_deref(), query_alias_manager, contextualizer)?;
+
+        // [$compute (With context changes)]
+        Compute::process(options.compute.as_deref(), contextualizer)?;
+
+        // [$count (SELECT) (With context changes)]
+        let count_text = Count::process(query_alias_manager, contextualizer)?;
+
+        // [$filter (Without context changes)]
+        let filter_text = Filter::process(options.filter.as_deref(), query_alias_manager, contextualizer)?;
+
+        // [$top (Without context changes)]
+        let mut top_text: String = String::from("");
+        if let Some(text) = &options.top {
+            top_text = Top::process(text)?;
+        }
+
+        // [$skip (Without context changes)]
+        let mut skip_text: String = String::from("");
+        if let Some(text) = &options.skip {
+            skip_text = Skip::process(text)?;
+        }
+
+        let mut sql = String::with_capacity(
+            count_text.len() + expand_text.len() + filter_text.len() + top_text.len() + skip_text.len() + 4,
+        );
+        
+        for text in [count_text, expand_text, filter_text, top_text, skip_text] {
+            if !text.is_empty() {
+                if !sql.is_empty() {
+                    sql.push('\n');
+                }
+                sql.push_str(text.as_str());
+            }
+        }
+
+        println!("\n{}", sql);
+        
+        Ok(sql)
+    }  
 }

--- a/src/services/query/database/sqlite/operations/count/context/context.rs
+++ b/src/services/query/database/sqlite/operations/count/context/context.rs
@@ -1,0 +1,23 @@
+use std::any::TypeId;
+
+use crate::database::sqlite::common::context::contextualizer::{ContextualizerColumnMetadata, ContextualizerMetadata};
+
+pub struct Context;
+
+impl Context {
+    pub fn resolve_context(
+        contextualizer: &mut ContextualizerMetadata,
+    ) -> Result<(), String> {  
+
+        let mut metadata = contextualizer.get_context();
+
+        let column_name = "count".to_string();
+        let column_type = TypeId::of::<i64>();
+
+        metadata.columns.insert(column_name.clone(), ContextualizerColumnMetadata::new(column_name, column_type));
+
+        contextualizer.update_context(metadata.clone());
+    
+        Ok(())
+    }
+}

--- a/src/services/query/database/sqlite/operations/count/count.rs
+++ b/src/services/query/database/sqlite/operations/count/count.rs
@@ -1,0 +1,60 @@
+use crate::{database::sqlite::common::context::contextualizer::ContextualizerMetadata, services::query::common::alias_manager::QueryAliasManager};
+
+use super::context::context::Context;
+
+pub struct Count;
+
+impl Count {
+    pub fn process(
+        alias_manager: &mut QueryAliasManager,
+        contextualizer: &mut ContextualizerMetadata,
+    ) -> Result<String, String> {
+
+        let error = |message: String| -> String {
+            format!("Invalid $count: {}", message)
+        };
+
+        let sql = match Self::process_select(alias_manager, contextualizer) {
+            Err(err) => return Err(error(err)),
+            Ok(value) => value
+        };
+
+        match Context::resolve_context(contextualizer) {
+            Err(err) => return Err(error(err)),
+            Ok(value) => value
+        };
+
+        Ok(sql)
+    }
+
+    pub fn process_select(
+        alias_manager: &mut QueryAliasManager,
+        contextualizer: &mut ContextualizerMetadata,
+    ) -> Result<String, String> {
+
+        let mut sql: String = String::from("");
+
+        let metadata = contextualizer.get_context();
+
+        sql.push_str("SELECT\n");
+
+        let table_alias: String = alias_manager.get_or_create_table_alias(&metadata.table_name);
+
+        let column_name = "count".to_string();
+
+        let field_alias: String = alias_manager.get_or_create_field_alias(&column_name);
+            
+        sql.push_str(&format!(
+            "COUNT(*) AS [{}]",
+            field_alias
+        ));
+
+        sql.push_str("\n");
+
+        // [FROM clause]
+        sql.push_str("FROM\n");
+        sql.push_str(&format!("[{}] AS [{}]", metadata.table_name, table_alias));
+        
+        Ok(sql)
+    }
+}

--- a/src/services/query/database/sqlite/operations/filter/compute/compute.rs
+++ b/src/services/query/database/sqlite/operations/filter/compute/compute.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 use lazy_static::lazy_static;
 
-use crate::database::mssql::common::context::contextualizer::ContextualizerEntityDescription;
 use crate::services::query::common::alias_manager::QueryAliasManager;
-use crate::database::sqlite::common::context::contextualizer::{ContextualizerColumnMetadata, ComputeArithmeticOperation, ComputeOperation, ComputeSpecificationMetadata};
+use crate::database::sqlite::common::context::contextualizer::{ContextualizerColumnMetadata, ComputeArithmeticOperation, ComputeOperation};
 use crate::services::query::database::sqlite::common::tokens::filter::token::Operation;
 
 #[derive(Hash, Eq, PartialEq, Debug)]

--- a/src/services/query/database/sqlite/operations/filter/filter.rs
+++ b/src/services/query/database/sqlite/operations/filter/filter.rs
@@ -49,10 +49,9 @@ impl Filter {
         };
 
         let mut sql: String = String::from("");
-        let mut tokens: Vec<Token> = Vec::new();
 
         if let Some(text) = text {
-            tokens = match Tokenization::tokenize(text, contextualizer) {
+            let tokens = match Tokenization::tokenize(text, contextualizer) {
                 Err(err) => return Err(error(err)),
                 Ok(value) => value
             };
@@ -84,9 +83,15 @@ impl Filter {
                 .unwrap()
         };
 
+        let mut needs_space = false;
+
         for token in tokens {
 
-            sql.push_str(" ");
+            if needs_space {
+                sql.push(' ');
+
+                needs_space = false;
+            }
 
             match token {
                 Token::Parentheses { parentheses } => {
@@ -101,6 +106,9 @@ impl Filter {
                     }
                 },
                 Token::Increment { increment } => {
+
+                    needs_space = true;
+
                     match increment {
                         Increment::And => sql.push_str("OR"),
                         Increment::Or => sql.push_str("AND")
@@ -108,6 +116,8 @@ impl Filter {
                 },
                 Token::Property { metadata, column_metadata, operation } => {
                     
+                    needs_space = true;
+
                     match column_metadata {
                         ContextualizerColumnMetadata::Original { column_name, .. } => {
 
@@ -120,7 +130,7 @@ impl Filter {
 
                                         sql.push_str(&format!(
                                             "[{}].[{}] {} {}",
-                                            alias, column_metadata.column_name(), operator, value
+                                            alias, column_name, operator, value
                                         ));
                                     },
                                     Operation::NotEqual { value } => {
@@ -129,7 +139,7 @@ impl Filter {
 
                                         sql.push_str(&format!(
                                             "[{}].[{}] {} {}",
-                                            alias, column_metadata.column_name(), operator, value
+                                            alias, column_name, operator, value
                                         ));
                                     },
                                     Operation::GreaterThan { value } => {
@@ -138,7 +148,7 @@ impl Filter {
 
                                         sql.push_str(&format!(
                                             "[{}].[{}] {} {}",
-                                            alias, column_metadata.column_name(), operator, value
+                                            alias, column_name, operator, value
                                         ));
                                     },
                                     Operation::GreaterThanOrEqual { value } => {
@@ -147,7 +157,7 @@ impl Filter {
 
                                         sql.push_str(&format!(
                                             "[{}].[{}] {} {}",
-                                            alias, column_metadata.column_name(), operator, value
+                                            alias, column_name, operator, value
                                         ));
                                     },
                                     Operation::LessThan { value } => {
@@ -156,7 +166,7 @@ impl Filter {
 
                                         sql.push_str(&format!(
                                             "[{}].[{}] {} {}",
-                                            alias, column_metadata.column_name(), operator, value
+                                            alias, column_name, operator, value
                                         ));
                                     },
                                     Operation::LessThanOrEqual { value } => {
@@ -165,7 +175,7 @@ impl Filter {
 
                                         sql.push_str(&format!(
                                             "[{}].[{}] {} {}",
-                                            alias, column_metadata.column_name(), operator, value
+                                            alias, column_name, operator, value
                                         ));
                                     },
                                     Operation::Like { value } => {
@@ -174,7 +184,7 @@ impl Filter {
 
                                         sql.push_str(&format!(
                                             "[{}].[{}] {} {}",
-                                            alias, column_metadata.column_name(), operator, value
+                                            alias, column_name, operator, value
                                         ));
                                     },
                                     Operation::InValues { value } => {
@@ -183,7 +193,7 @@ impl Filter {
 
                                         sql.push_str(&format!(
                                             "[{}].[{}] {} ({})",
-                                            alias, column_metadata.column_name(), operator, value.join(",")
+                                            alias, column_name, operator, value.join(",")
                                         ));
                                     },
                                 }

--- a/src/services/query/database/sqlite/operations/orderby/compute/compute.rs
+++ b/src/services/query/database/sqlite/operations/orderby/compute/compute.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use lazy_static::lazy_static;
 
 use crate::services::query::common::alias_manager::QueryAliasManager;
-use crate::database::sqlite::common::context::contextualizer::{ContextualizerColumnMetadata, ComputeArithmeticOperation, ComputeOperation, ComputeSpecificationMetadata};
+use crate::database::sqlite::common::context::contextualizer::{ContextualizerColumnMetadata, ComputeArithmeticOperation, ComputeOperation};
 
 #[derive(Hash, Eq, PartialEq, Debug)]
 enum ArithmeticOperationType {

--- a/src/services/query/database/sqlite/operations/orderby/orderby.rs
+++ b/src/services/query/database/sqlite/operations/orderby/orderby.rs
@@ -19,10 +19,9 @@ impl Orderby {
         };
 
         let mut sql: String = String::from("");
-        let mut tokens: Vec<Token> = Vec::new();
 
         if let Some(text) = text {
-            tokens = match Tokenization::tokenize(text, contextualizer) {
+            let tokens = match Tokenization::tokenize(text, contextualizer) {
                 Err(err) => return Err(error(err)),
                 Ok(value) => value
             };

--- a/src/services/query/database/sqlite/operations/select/compute/compute.rs
+++ b/src/services/query/database/sqlite/operations/select/compute/compute.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use lazy_static::lazy_static;
 
 use crate::services::query::common::alias_manager::QueryAliasManager;
-use crate::database::sqlite::common::context::contextualizer::{ContextualizerColumnMetadata, ComputeArithmeticOperation, ComputeOperation, ComputeSpecificationMetadata};
+use crate::database::sqlite::common::context::contextualizer::{ContextualizerColumnMetadata, ComputeArithmeticOperation, ComputeOperation};
 
 #[derive(Hash, Eq, PartialEq, Debug)]
 enum ArithmeticOperationType {

--- a/src/services/query/database/sqlite/operations/select/select.rs
+++ b/src/services/query/database/sqlite/operations/select/select.rs
@@ -1,36 +1,9 @@
-use std::collections::HashMap;
-
-use lazy_static::lazy_static;
-
 use crate::services::query::common::alias_manager::QueryAliasManager;
 
-use crate::database::sqlite::common::context::contextualizer::{ComputeArithmeticOperation, ComputeOperation, ContextualizerColumnMetadata, ContextualizerMetadata};
+use crate::database::sqlite::common::context::contextualizer::{ContextualizerColumnMetadata, ContextualizerMetadata};
 use crate::services::query::database::sqlite::common::tokens::select::token::Token;
 
-use super::compute::compute::Compute;
-use super::token::tokenization::Tokenization;
-
-#[derive(Hash, Eq, PartialEq, Debug)]
-enum ArithmeticOperationType {
-    Addition,
-    Subtration,
-    Multiplication,
-    Division,
-    Module
-}
-
-lazy_static! {
-    static ref ARITHMETIC_OPERATORS: HashMap<ArithmeticOperationType, &'static str> = {
-        let mut map = HashMap::new();
-        map.insert(ArithmeticOperationType::Addition, "+");
-        map.insert(ArithmeticOperationType::Subtration, "-");
-        map.insert(ArithmeticOperationType::Multiplication, "*");
-        map.insert(ArithmeticOperationType::Division, "/");
-        map.insert(ArithmeticOperationType::Module, "%");
-        map
-    };
-}
-
+use super::{token::tokenization::Tokenization, compute::compute::Compute};
 
 pub struct Select;
 
@@ -45,12 +18,11 @@ impl Select {
             format!("Invalid $select: {}", message)
         };
 
-        let mut sql: String = String::from("");
-        let mut tokens: Vec<Token> = Vec::new();
+        let sql: String;
 
         if let Some(text) = text {
 
-            tokens = match Tokenization::tokenize(text, contextualizer) {
+            let tokens = match Tokenization::tokenize(text, contextualizer) {
                 Err(err) => return Err(error(err)),
                 Ok(value) => value
             };

--- a/src/services/query/database/sqlite/query.rs
+++ b/src/services/query/database/sqlite/query.rs
@@ -4,6 +4,7 @@ use crate::dto::query_params::QueryParams;
 use crate::database::sqlite::common::context::contextualizer::ContextualizerMetadata;
 
 use crate::services::query::database::sqlite::operations::compute::compute::Compute;
+use crate::services::query::database::sqlite::operations::count::count::Count;
 use crate::services::query::database::sqlite::operations::select::select::Select;
 use crate::services::query::database::sqlite::operations::filter::filter::Filter;
 use crate::services::query::database::sqlite::operations::expand::expand::Expand;
@@ -48,18 +49,70 @@ impl Query {
             skip_text = Skip::process(text)?;
         }
 
-        let sql = format!(
-            "{}\n{}\n{}\n{}\n{}\n{}",
-            select_text,
-            expand_text,
-            filter_text,
-            orderby_text,
-            top_text,
-            skip_text
+        let mut sql = String::with_capacity(
+            select_text.len() + expand_text.len() + filter_text.len() + orderby_text.len() + top_text.len() + skip_text.len() + 4,
         );
+        
+        for text in [select_text, expand_text, filter_text, orderby_text, top_text, skip_text] {
+            if !text.is_empty() {
+                if !sql.is_empty() {
+                    sql.push('\n');
+                }
+                sql.push_str(text.as_str());
+            }
+        }
 
-        println!("Final query: \n{}", sql);
+        println!("\n{}", sql);
         
         Ok(sql)
-    }    
+    }  
+
+    pub fn build_query_count(
+        &self,
+        options: &QueryParams,
+        query_alias_manager: &mut QueryAliasManager,
+        contextualizer: &mut ContextualizerMetadata,
+    ) -> Result<String, String> {
+
+        // [$expand (With context changes)]
+        let expand_text = Expand::process(options.expand.as_deref(), query_alias_manager, contextualizer)?;
+
+        // [$compute (With context changes)]
+        Compute::process(options.compute.as_deref(), contextualizer)?;
+
+        // [$count (SELECT) (With context changes)]
+        let count_text = Count::process(query_alias_manager, contextualizer)?;
+
+        // [$filter (Without context changes)]
+        let filter_text = Filter::process(options.filter.as_deref(), query_alias_manager, contextualizer)?;
+
+        // [$top (Without context changes)]
+        let mut top_text: String = String::from("");
+        if let Some(text) = &options.top {
+            top_text = Top::process(text)?;
+        }
+
+        // [$skip (Without context changes)]
+        let mut skip_text: String = String::from("");
+        if let Some(text) = &options.skip {
+            skip_text = Skip::process(text)?;
+        }
+
+        let mut sql = String::with_capacity(
+            count_text.len() + expand_text.len() + filter_text.len() + top_text.len() + skip_text.len() + 4,
+        );
+        
+        for text in [count_text, expand_text, filter_text, top_text, skip_text] {
+            if !text.is_empty() {
+                if !sql.is_empty() {
+                    sql.push('\n');
+                }
+                sql.push_str(text.as_str());
+            }
+        }
+
+        println!("\n{}", sql);
+        
+        Ok(sql)
+    }  
 }


### PR DESCRIPTION
● Key points:

• Inclusion of queries that return only the count. (For pagination)

• For future, verify the situation in nested tables with the same name. Example:

Table1.Table2.Table3.Table1

You can see that the second line have a nested relation between four tables and the last is the same name of Table1.

In this cases, I need to test and think about solutions.